### PR TITLE
Make ID generation of Team Engine test suites independent of deployment URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,25 @@ cache:
   - "$HOME/.gradle"
 before_script:
 - export TZ=Europe/Berlin
-script:
-- "./gradlew init"
-- "./gradlew -Dorg.gradle.project.ii.etfdev.quality.reports=true test jacocoTestReport"
+stages:
+- name: build
+  if: branch = master || branch = next
+- name: deploy
+  if: branch = next && type != pull_request
+jobs:
+  include:
+    - stage: build
+      script:
+        - "./gradlew -Dorg.gradle.project.ii.etfdev.quality.reports=true build jacocoTestReport"
+    - stage: deploy
+      script:
+        - "./gradlew build -x test"
+      deploy:
+        skip_cleanup: true
+        provider: s3
+        access_key_id: ${AWS_ACCESS_KEY}
+        secret_access_key: ${AWS_SECRET_KEY}
+        bucket: ${AWS_S3_BUCKET}
+        region: ${AWS_S3_REGION}
+        upload-dir: ${AWS_S3_BUCKET_TARGET_PATH}
+        local_dir: build/libs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 os:
 - linux
 branches:

--- a/src/main/java/de/interactive_instruments/etf/testdriver/te/TeTestDriver.java
+++ b/src/main/java/de/interactive_instruments/etf/testdriver/te/TeTestDriver.java
@@ -60,134 +60,134 @@ import de.interactive_instruments.properties.ConfigProperties;
 @ComponentInitializer(id = TE_TEST_DRIVER_EID)
 public class TeTestDriver extends AbstractTestDriver {
 
-	public static final String TE_TEST_DRIVER_EID = "07f42606-41b1-4871-a83b-64c20012f03b";
-	public static final String TE_REMOTE_URL = "etf.testdrivers.teamengine.url";
-	public static final String TE_REMOTE_USERNAME = "etf.testdrivers.teamengine.username";
-	public static final String TE_REMOTE_PASSWORD = "etf.testdrivers.teamengine.password";
-	// timeout in seconds
-	public static final String TE_TIMEOUT_SEC = "etf.testdrivers.teamengine.timeout";
-	private DataStorage dataStorageCallback;
-	private URI apiUri;
-	private Credentials credentials;
-	private static final String supportedTeamEngineVersion = CLUtils.getManifestAttributeValue(TeTestDriver.class,
-			"Test-Engine-Version");
+    public static final String TE_TEST_DRIVER_EID = "07f42606-41b1-4871-a83b-64c20012f03b";
+    public static final String TE_REMOTE_URL = "etf.testdrivers.teamengine.url";
+    public static final String TE_REMOTE_USERNAME = "etf.testdrivers.teamengine.username";
+    public static final String TE_REMOTE_PASSWORD = "etf.testdrivers.teamengine.password";
+    // timeout in seconds
+    public static final String TE_TIMEOUT_SEC = "etf.testdrivers.teamengine.timeout";
+    private DataStorage dataStorageCallback;
+    private URI apiUri;
+    private Credentials credentials;
+    private static final String supportedTeamEngineVersion = CLUtils.getManifestAttributeValue(TeTestDriver.class,
+            "Test-Engine-Version");
 
-	final static ComponentInfo COMPONENT_INFO = new ComponentInfo() {
-		@Override
-		public String getName() {
-			return "TEAM Engine test driver";
-		}
+    final static ComponentInfo COMPONENT_INFO = new ComponentInfo() {
+        @Override
+        public String getName() {
+            return "TEAM Engine test driver";
+        }
 
-		@Override
-		public EID getId() {
-			return EidFactory.getDefault().createAndPreserveStr(TE_TEST_DRIVER_EID);
-		}
+        @Override
+        public EID getId() {
+            return EidFactory.getDefault().createAndPreserveStr(TE_TEST_DRIVER_EID);
+        }
 
-		@Override
-		public String getVersion() {
-			return this.getClass().getPackage().getImplementationVersion();
-		}
+        @Override
+        public String getVersion() {
+            return this.getClass().getPackage().getImplementationVersion();
+        }
 
-		@Override
-		public String getVendor() {
-			return this.getClass().getPackage().getImplementationVendor();
-		}
+        @Override
+        public String getVendor() {
+            return this.getClass().getPackage().getImplementationVendor();
+        }
 
-		@Override
-		public String getDescription() {
-			return "Test driver for TEAM Engine " + supportedTeamEngineVersion;
-		}
-	};
+        @Override
+        public String getDescription() {
+            return "Test driver for TEAM Engine " + supportedTeamEngineVersion;
+        }
+    };
 
-	public TeTestDriver() {
-		super(new ConfigProperties());
-	}
+    public TeTestDriver() {
+        super(new ConfigProperties());
+    }
 
-	@Override
-	public Collection<TestObjectTypeDto> getTestObjectTypes() {
-		return TE_SUPPORTED_TEST_OBJECT_TYPES.values();
-	}
+    @Override
+    public Collection<TestObjectTypeDto> getTestObjectTypes() {
+        return TE_SUPPORTED_TEST_OBJECT_TYPES.values();
+    }
 
-	@Override
-	final public ComponentInfo getInfo() {
-		return COMPONENT_INFO;
-	}
+    @Override
+    final public ComponentInfo getInfo() {
+        return COMPONENT_INFO;
+    }
 
-	@Override
-	public TestTask createTestTask(final TestTaskDto testTaskDto) throws TestTaskInitializationException {
-		try {
-			Objects.requireNonNull(testTaskDto, "Test Task not set").ensureBasicValidity();
+    @Override
+    public TestTask createTestTask(final TestTaskDto testTaskDto) throws TestTaskInitializationException {
+        try {
+            Objects.requireNonNull(testTaskDto, "Test Task not set").ensureBasicValidity();
 
-			// Get ETS
-			testTaskDto.getTestObject().ensureBasicValidity();
-			testTaskDto.getExecutableTestSuite().ensureBasicValidity();
-			final TestTaskResultDto testTaskResult = new TestTaskResultDto();
-			testTaskResult.setId(EidFactory.getDefault().createRandomId());
-			testTaskDto.setTestTaskResult(testTaskResult);
-			return new TeTestTask(
-					(int) TimeUnit.SECONDS.toMillis(configProperties.getPropertyOrDefaultAsInt(TE_TIMEOUT_SEC, 1200)),
-					credentials, (TeTypeLoader) typeLoader, testTaskDto);
-		} catch (IncompleteDtoException e) {
-			throw new TestTaskInitializationException(e);
-		} catch (InvalidPropertyException e) {
-			throw new TestTaskInitializationException(e);
-		}
+            // Get ETS
+            testTaskDto.getTestObject().ensureBasicValidity();
+            testTaskDto.getExecutableTestSuite().ensureBasicValidity();
+            final TestTaskResultDto testTaskResult = new TestTaskResultDto();
+            testTaskResult.setId(EidFactory.getDefault().createRandomId());
+            testTaskDto.setTestTaskResult(testTaskResult);
+            return new TeTestTask(
+                    (int) TimeUnit.SECONDS.toMillis(configProperties.getPropertyOrDefaultAsInt(TE_TIMEOUT_SEC, 1200)),
+                    credentials, (TeTypeLoader) typeLoader, testTaskDto);
+        } catch (IncompleteDtoException e) {
+            throw new TestTaskInitializationException(e);
+        } catch (InvalidPropertyException e) {
+            throw new TestTaskInitializationException(e);
+        }
 
-	}
+    }
 
-	@Override
-	final public void doInit()
-			throws ConfigurationException, IllegalStateException, InitializationException, InvalidStateTransitionException {
-		dataStorageCallback = DataStorageRegistry.instance().get(configProperties.getProperty(ETF_DATA_STORAGE_NAME));
-		if (dataStorageCallback == null) {
-			throw new InvalidStateTransitionException("Data Storage not set");
-		}
+    @Override
+    final public void doInit()
+            throws ConfigurationException, IllegalStateException, InitializationException, InvalidStateTransitionException {
+        dataStorageCallback = DataStorageRegistry.instance().get(configProperties.getProperty(ETF_DATA_STORAGE_NAME));
+        if (dataStorageCallback == null) {
+            throw new InvalidStateTransitionException("Data Storage not set");
+        }
 
-		final String teUrl = configProperties.getPropertyOrDefault(TE_REMOTE_URL,
-				"http://cite.opengeospatial.org/teamengine");
-		if (SUtils.isNullOrEmpty(teUrl)) {
-			throw new ConfigurationException("Property " + TE_REMOTE_URL + " not set");
-		}
-		try {
-			if (teUrl.charAt(teUrl.length() - 1) == '/') {
-				apiUri = new URI(teUrl);
-			} else {
-				apiUri = new URI(teUrl + "/");
-			}
-		} catch (URISyntaxException e) {
-			throw new ConfigurationException("Property " + TE_REMOTE_URL + " must be an URL");
-		}
+        final String teUrl = configProperties.getPropertyOrDefault(TE_REMOTE_URL,
+                "http://cite.opengeospatial.org/teamengine");
+        if (SUtils.isNullOrEmpty(teUrl)) {
+            throw new ConfigurationException("Property " + TE_REMOTE_URL + " not set");
+        }
+        try {
+            if (teUrl.charAt(teUrl.length() - 1) == '/') {
+                apiUri = new URI(teUrl);
+            } else {
+                apiUri = new URI(teUrl + "/");
+            }
+        } catch (URISyntaxException e) {
+            throw new ConfigurationException("Property " + TE_REMOTE_URL + " must be an URL");
+        }
 
-		if (configProperties.hasProperty(TE_REMOTE_USERNAME) && configProperties.hasProperty(TE_REMOTE_PASSWORD)) {
-			credentials = new Credentials(configProperties.getProperty(TE_REMOTE_USERNAME),
-					configProperties.getProperty(TE_REMOTE_PASSWORD));
-		} else {
-			credentials = null;
-		}
+        if (configProperties.hasProperty(TE_REMOTE_USERNAME) && configProperties.hasProperty(TE_REMOTE_PASSWORD)) {
+            credentials = new Credentials(configProperties.getProperty(TE_REMOTE_USERNAME),
+                    configProperties.getProperty(TE_REMOTE_PASSWORD));
+        } else {
+            credentials = null;
+        }
 
-		propagateComponents();
+        propagateComponents();
 
-		typeLoader = new TeTypeLoader(dataStorageCallback, apiUri, credentials, this.getInfo());
-		typeLoader.getConfigurationProperties().setPropertiesFrom(configProperties, true);
-	}
+        typeLoader = new TeTypeLoader(dataStorageCallback, apiUri, credentials, this.getInfo());
+        typeLoader.getConfigurationProperties().setPropertiesFrom(configProperties, true);
+    }
 
-	@Override
-	protected void doRelease() {
+    @Override
+    protected void doRelease() {
 
-	}
+    }
 
-	private void propagateComponents() throws InitializationException {
-		// Propagate Component COMPONENT_INFO from here
-		final WriteDao<ComponentDto> componentDao = ((WriteDao<ComponentDto>) dataStorageCallback.getDao(ComponentDto.class));
-		try {
-			try {
-				componentDao.delete(this.getInfo().getId());
-			} catch (ObjectWithIdNotFoundException e) {
-				ExcUtils.suppress(e);
-			}
-			componentDao.add(new ComponentDto(this.getInfo()));
-		} catch (StorageException e) {
-			throw new InitializationException(e);
-		}
-	}
+    private void propagateComponents() throws InitializationException {
+        // Propagate Component COMPONENT_INFO from here
+        final WriteDao<ComponentDto> componentDao = ((WriteDao<ComponentDto>) dataStorageCallback.getDao(ComponentDto.class));
+        try {
+            try {
+                componentDao.delete(this.getInfo().getId());
+            } catch (ObjectWithIdNotFoundException e) {
+                ExcUtils.suppress(e);
+            }
+            componentDao.add(new ComponentDto(this.getInfo()));
+        } catch (StorageException e) {
+            throw new InitializationException(e);
+        }
+    }
 }

--- a/src/main/java/de/interactive_instruments/etf/testdriver/te/TeTestTask.java
+++ b/src/main/java/de/interactive_instruments/etf/testdriver/te/TeTestTask.java
@@ -61,358 +61,359 @@ import de.interactive_instruments.exceptions.config.ConfigurationException;
  */
 class TeTestTask extends AbstractTestTask {
 
-	private final int timeout;
-	private final Credentials credentials;
-	private final TeTypeLoader typeLoader;
-	private final String etsSpecificPrefix;
+    private final int timeout;
+    private final Credentials credentials;
+    private final TeTypeLoader typeLoader;
+    private final String etsSpecificPrefix;
 
-	/**
-	 * Default constructor.
-	 *
-	 * @throws IOException I/O error
-	 */
-	public TeTestTask(final int timeout, final Credentials credentials, final TeTypeLoader typeLoader,
-			final TestTaskDto testTaskDto) {
-		super(testTaskDto, new TeTestTaskProgress(), TeTestTask.class.getClassLoader());
-		this.timeout = timeout;
-		this.credentials = credentials;
-		this.typeLoader = typeLoader;
-		etsSpecificPrefix = testTaskDto.getExecutableTestSuite().getId().getId() +
-				testTaskDto.getExecutableTestSuite().getLabel();
-	}
+    /**
+     * Default constructor.
+     *
+     * @throws IOException
+     *             I/O error
+     */
+    public TeTestTask(final int timeout, final Credentials credentials, final TeTypeLoader typeLoader,
+            final TestTaskDto testTaskDto) {
+        super(testTaskDto, new TeTestTaskProgress(), TeTestTask.class.getClassLoader());
+        this.timeout = timeout;
+        this.credentials = credentials;
+        this.typeLoader = typeLoader;
+        etsSpecificPrefix = testTaskDto.getExecutableTestSuite().getId().getId() +
+                testTaskDto.getExecutableTestSuite().getLabel();
+    }
 
-	@Override
-	protected void doRun() throws Exception {
-		final DocumentBuilderFactory domFactory = XmlUtils.newDocumentBuilderFactoryInstance();
-		domFactory.setNamespaceAware(true);
-		final DocumentBuilder builder = domFactory.newDocumentBuilder();
+    @Override
+    protected void doRun() throws Exception {
+        final DocumentBuilderFactory domFactory = XmlUtils.newDocumentBuilderFactoryInstance();
+        domFactory.setNamespaceAware(true);
+        final DocumentBuilder builder = domFactory.newDocumentBuilder();
 
-		final String endpoint = this.testTaskDto.getTestObject().getResourceByName(
-				"serviceEndpoint").toString();
+        final String endpoint = this.testTaskDto.getTestObject().getResourceByName(
+                "serviceEndpoint").toString();
 
-		// TEAM engine can not escape characters other than '&' in the parameter values...
-		// Try to build an URI without escaping other characters.
-		URI apiUri;
-		String wfsUrl;
-		try {
-			wfsUrl = UriUtils.ensureUrlEncodedOnce(endpoint);
-			final String apiUrl = testTaskDto.getExecutableTestSuite().getRemoteResource().toString() +
-					"run?wfs=" + wfsUrl;
-			apiUri = new URI(apiUrl);
-		} catch (URISyntaxException syntaxException) {
-			// great, try again with an escaped URL. Maybe this is supported in future TE versions...
-			final String apiUriFallback = UriUtils.withQueryParameters(
-					testTaskDto.getExecutableTestSuite().getRemoteResource().toString() + "run",
-					Collections.singletonMap("wfs", endpoint));
-			getLogger().error("Team Engine does not support full escaping of URLs. "
-					+ "The invocation of the following URL might fail with HTTP error code 404: {} .",
-					apiUriFallback);
-			wfsUrl = endpoint;
-			apiUri = new URI(apiUriFallback);
-		}
+        // TEAM engine can not escape characters other than '&' in the parameter values...
+        // Try to build an URI without escaping other characters.
+        URI apiUri;
+        String wfsUrl;
+        try {
+            wfsUrl = UriUtils.ensureUrlEncodedOnce(endpoint);
+            final String apiUrl = testTaskDto.getExecutableTestSuite().getRemoteResource().toString() +
+                    "run?wfs=" + wfsUrl;
+            apiUri = new URI(apiUrl);
+        } catch (URISyntaxException syntaxException) {
+            // great, try again with an escaped URL. Maybe this is supported in future TE versions...
+            final String apiUriFallback = UriUtils.withQueryParameters(
+                    testTaskDto.getExecutableTestSuite().getRemoteResource().toString() + "run",
+                    Collections.singletonMap("wfs", endpoint));
+            getLogger().error("Team Engine does not support full escaping of URLs. "
+                    + "The invocation of the following URL might fail with HTTP error code 404: {} .",
+                    apiUriFallback);
+            wfsUrl = endpoint;
+            apiUri = new URI(apiUriFallback);
+        }
 
-		getLogger().info("Invoking TEAM Engine remotely. This may take a while. "
-				+ "Progress messages are not supported.");
-		final String timeoutStr = TimeUtils.milisAsMinsSeconds(timeout);
-		getLogger().info("Timeout is set to: " + timeoutStr);
-		((TeTestTaskProgress) progress).stepCompleted();
+        getLogger().info("Invoking TEAM Engine remotely. This may take a while. "
+                + "Progress messages are not supported.");
+        final String timeoutStr = TimeUtils.milisAsMinsSeconds(timeout);
+        getLogger().info("Timeout is set to: " + timeoutStr);
+        ((TeTestTaskProgress) progress).stepCompleted();
 
-		final Document result;
-		try {
-			// application/xml = TestNG
-			result = builder.parse(UriUtils.openStream(apiUri, credentials, timeout, "application/xml"));
-		} catch (UriUtils.ConnectionException e) {
-			getLogger().info("OGC TEAM Engine returned an error.");
+        final Document result;
+        try {
+            // application/xml = TestNG
+            result = builder.parse(UriUtils.openStream(apiUri, credentials, timeout, "application/xml"));
+        } catch (UriUtils.ConnectionException e) {
+            getLogger().info("OGC TEAM Engine returned an error.");
 
-			final String htmlErrorMessage = e.getErrorMessage();
-			String errorMessage = null;
-			if (htmlErrorMessage != null) {
-				try {
-					final org.jsoup.nodes.Document doc = Jsoup.parse(htmlErrorMessage);
-					if (doc != null) {
-						final Elements errors = doc.select("body p");
-						if (errors != null) {
-							final StringBuilder errorMessageBuilder = new StringBuilder();
-							for (final org.jsoup.nodes.Element error : errors) {
-								errorMessageBuilder.append(error.text()).append(SUtils.ENDL);
-							}
-							errorMessage = errorMessageBuilder.toString();
-						}
-					}
-				} catch (Exception ign) {
-					ExcUtils.suppress(ign);
-				}
-			}
-			if (errorMessage != null) {
-				getLogger().error("Error message: {}", errorMessage);
-				reportError(
-						"OGC TEAM Engine returned HTTP status code: "
-								+ String.valueOf(e.getResponseMessage()
-										+ ". Message: " + errorMessage),
-						htmlErrorMessage.getBytes(),
-						"text/html");
-			} else {
-				getLogger().error("Response message: " + e.getResponseMessage());
-				reportError(
-						"OGC TEAM Engine returned an error: " +
-								String.valueOf(e.getResponseMessage()),
-						null, null);
-			}
-			throw e;
-		} catch (final SocketTimeoutException e) {
-			getLogger().info("The OGC TEAM Engine is taking too long to respond.");
-			getLogger().info("Checking availability...");
-			if (UriUtils.exists(new URI(
-					testTaskDto.getExecutableTestSuite().getRemoteResource().toString()), credentials)) {
-				getLogger().info("...[OK]. The OGC TEAM Engine is available. "
-						+ "You may need to ask the system administrator to "
-						+ "increase the OGC TEAM Engine test driver timeout.");
-			} else {
-				getLogger().info("...[FAILED]. The OGC TEAM Engine is not available. "
-						+ "Try re-running the test after a few minutes.");
-			}
-			reportError(
-					"OGC TEAM Engine is taking too long to respond. "
-							+ "Timeout after " + timeoutStr + ".",
-					null, null);
-			throw e;
-		}
+            final String htmlErrorMessage = e.getErrorMessage();
+            String errorMessage = null;
+            if (htmlErrorMessage != null) {
+                try {
+                    final org.jsoup.nodes.Document doc = Jsoup.parse(htmlErrorMessage);
+                    if (doc != null) {
+                        final Elements errors = doc.select("body p");
+                        if (errors != null) {
+                            final StringBuilder errorMessageBuilder = new StringBuilder();
+                            for (final org.jsoup.nodes.Element error : errors) {
+                                errorMessageBuilder.append(error.text()).append(SUtils.ENDL);
+                            }
+                            errorMessage = errorMessageBuilder.toString();
+                        }
+                    }
+                } catch (Exception ign) {
+                    ExcUtils.suppress(ign);
+                }
+            }
+            if (errorMessage != null) {
+                getLogger().error("Error message: {}", errorMessage);
+                reportError(
+                        "OGC TEAM Engine returned HTTP status code: "
+                                + String.valueOf(e.getResponseMessage()
+                                        + ". Message: " + errorMessage),
+                        htmlErrorMessage.getBytes(),
+                        "text/html");
+            } else {
+                getLogger().error("Response message: " + e.getResponseMessage());
+                reportError(
+                        "OGC TEAM Engine returned an error: " +
+                                String.valueOf(e.getResponseMessage()),
+                        null, null);
+            }
+            throw e;
+        } catch (final SocketTimeoutException e) {
+            getLogger().info("The OGC TEAM Engine is taking too long to respond.");
+            getLogger().info("Checking availability...");
+            if (UriUtils.exists(new URI(
+                    testTaskDto.getExecutableTestSuite().getRemoteResource().toString()), credentials)) {
+                getLogger().info("...[OK]. The OGC TEAM Engine is available. "
+                        + "You may need to ask the system administrator to "
+                        + "increase the OGC TEAM Engine test driver timeout.");
+            } else {
+                getLogger().info("...[FAILED]. The OGC TEAM Engine is not available. "
+                        + "Try re-running the test after a few minutes.");
+            }
+            reportError(
+                    "OGC TEAM Engine is taking too long to respond. "
+                            + "Timeout after " + timeoutStr + ".",
+                    null, null);
+            throw e;
+        }
 
-		getLogger().info("Results received.");
-		((TeTestTaskProgress) progress).stepCompleted();
+        getLogger().info("Results received.");
+        ((TeTestTaskProgress) progress).stepCompleted();
 
-		if (typeLoader.updateEtsFromResult(testTaskDto.getExecutableTestSuite(), result)) {
-			getLogger().info("Internal ETS model updated.");
-		}
+        if (typeLoader.updateEtsFromResult(testTaskDto.getExecutableTestSuite(), result)) {
+            getLogger().info("Internal ETS model updated.");
+        }
 
-		parseTestNgResult(result);
-		((TeTestTaskProgress) progress).stepCompleted();
-	}
+        parseTestNgResult(result);
+        ((TeTestTaskProgress) progress).stepCompleted();
+    }
 
-	private void reportError(final String errorMesg, final byte[] data, final String mimeType)
-			throws ObjectWithIdNotFoundException, StorageException {
-		getCollector().internalError(errorMesg, data, mimeType);
-	}
+    private void reportError(final String errorMesg, final byte[] data, final String mimeType)
+            throws ObjectWithIdNotFoundException, StorageException {
+        getCollector().internalError(errorMesg, data, mimeType);
+    }
 
-	private void parseTestNgResult(final Document document) throws Exception {
-		getLogger().info("Transforming results.");
-		final Element result = document.getDocumentElement();
-		if (!"testng-results".equals(result.getNodeName())) {
-			throw new ParseException("Expected a TestNG result XML", document.getDocumentURI(), 0);
-		}
+    private void parseTestNgResult(final Document document) throws Exception {
+        getLogger().info("Transforming results.");
+        final Element result = document.getDocumentElement();
+        if (!"testng-results".equals(result.getNodeName())) {
+            throw new ParseException("Expected a TestNG result XML", document.getDocumentURI(), 0);
+        }
 
-		final String failedAssertions = XmlUtils.getAttribute(result, "failed");
-		final String passedAssertions = XmlUtils.getAttribute(result, "passed");
-		final Integer passedAssertionsInt = Integer.valueOf(passedAssertions);
-		getLogger().info("{} of {} assertions passed", passedAssertionsInt,
-				Integer.valueOf(passedAssertions + Integer.valueOf(failedAssertions)));
+        final String failedAssertions = XmlUtils.getAttribute(result, "failed");
+        final String passedAssertions = XmlUtils.getAttribute(result, "passed");
+        final Integer passedAssertionsInt = Integer.valueOf(passedAssertions);
+        getLogger().info("{} of {} assertions passed", passedAssertionsInt,
+                Integer.valueOf(passedAssertions + Integer.valueOf(failedAssertions)));
 
-		final TestResultCollector resultCollector = getCollector();
+        final TestResultCollector resultCollector = getCollector();
 
-		final Node suiteResult = XmlUtils.getFirstChildNodeOfType(result, ELEMENT_NODE, "suite");
-		resultCollector.startTestTask(testTaskDto.getExecutableTestSuite().getId().getId(), getStartTimestamp(suiteResult));
+        final Node suiteResult = XmlUtils.getFirstChildNodeOfType(result, ELEMENT_NODE, "suite");
+        resultCollector.startTestTask(testTaskDto.getExecutableTestSuite().getId().getId(), getStartTimestamp(suiteResult));
 
-		// Save result document as attachment
-		final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-		final Source xmlSource = new DOMSource(document);
-		final Result outputTarget = new StreamResult(outputStream);
-		TransformerFactory.newInstance().newTransformer().transform(xmlSource, outputTarget);
-		final InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
-		resultCollector.saveAttachment(inputStream, "TEAM Engine result", "text/xml", "TestNgResultXml");
+        // Save result document as attachment
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        final Source xmlSource = new DOMSource(document);
+        final Result outputTarget = new StreamResult(outputStream);
+        TransformerFactory.newInstance().newTransformer().transform(xmlSource, outputTarget);
+        final InputStream inputStream = new ByteArrayInputStream(outputStream.toByteArray());
+        resultCollector.saveAttachment(inputStream, "TEAM Engine result", "text/xml", "TestNgResultXml");
 
-		// Test Modules
-		for (Node testModule = XmlUtils.getFirstChildNodeOfType(suiteResult, ELEMENT_NODE,
-				"test"); testModule != null; testModule = XmlUtils.getNextSiblingOfType(testModule, ELEMENT_NODE, "test")) {
-			final String testModuleId = getItemID(testModule);
-			resultCollector.startTestModule(testModuleId, getStartTimestamp(testModule));
+        // Test Modules
+        for (Node testModule = XmlUtils.getFirstChildNodeOfType(suiteResult, ELEMENT_NODE,
+                "test"); testModule != null; testModule = XmlUtils.getNextSiblingOfType(testModule, ELEMENT_NODE, "test")) {
+            final String testModuleId = getItemID(testModule);
+            resultCollector.startTestModule(testModuleId, getStartTimestamp(testModule));
 
-			// Test Cases
-			for (Node testCase = XmlUtils.getFirstChildNodeOfType(testModule, ELEMENT_NODE,
-					"class"); testCase != null; testCase = XmlUtils.getNextSiblingOfType(testCase, ELEMENT_NODE, "class")) {
-				final String testCaseId = getItemID(testCase);
+            // Test Cases
+            for (Node testCase = XmlUtils.getFirstChildNodeOfType(testModule, ELEMENT_NODE,
+                    "class"); testCase != null; testCase = XmlUtils.getNextSiblingOfType(testCase, ELEMENT_NODE, "class")) {
+                final String testCaseId = getItemID(testCase);
 
-				// Get start timestamp from first test step
-				final Node firstTestStep = XmlUtils.getFirstChildNodeOfType(testCase, ELEMENT_NODE, "test-method");
-				if (firstTestStep != null) {
-					resultCollector.startTestCase(testCaseId, getStartTimestamp(firstTestStep));
-				} else {
-					resultCollector.startTestCase(testCaseId);
-				}
-				long testCaseEndTimeStamp = 0;
-				boolean testStepResultCollected = false;
-				boolean oneSkippedOrNotApplicableConfigStepRecorded = false;
+                // Get start timestamp from first test step
+                final Node firstTestStep = XmlUtils.getFirstChildNodeOfType(testCase, ELEMENT_NODE, "test-method");
+                if (firstTestStep != null) {
+                    resultCollector.startTestCase(testCaseId, getStartTimestamp(firstTestStep));
+                } else {
+                    resultCollector.startTestCase(testCaseId);
+                }
+                long testCaseEndTimeStamp = 0;
+                boolean testStepResultCollected = false;
+                boolean oneSkippedOrNotApplicableConfigStepRecorded = false;
 
-				// Test Steps (no Test Assertions are used)
-				for (Node testStep = firstTestStep; testStep != null; testStep = XmlUtils.getNextSiblingOfType(testStep,
-						ELEMENT_NODE, "test-method")) {
+                // Test Steps (no Test Assertions are used)
+                for (Node testStep = firstTestStep; testStep != null; testStep = XmlUtils.getNextSiblingOfType(testStep,
+                        ELEMENT_NODE, "test-method")) {
 
-					final long testStepEndTimestamp = getEndTimestamp(testStep);
-					if (testCaseEndTimeStamp < testStepEndTimestamp) {
-						testCaseEndTimeStamp = testStepEndTimestamp;
-					}
+                    final long testStepEndTimestamp = getEndTimestamp(testStep);
+                    if (testCaseEndTimeStamp < testStepEndTimestamp) {
+                        testCaseEndTimeStamp = testStepEndTimestamp;
+                    }
 
-					final int status = mapStatus(testStep);
-					final boolean configStep = "true".equals(XmlUtils.getAttributeOrDefault(testStep, "is-config", "false"));
+                    final int status = mapStatus(testStep);
+                    final boolean configStep = "true".equals(XmlUtils.getAttributeOrDefault(testStep, "is-config", "false"));
 
-					// output only failed steps or only one skipped or not applicable config test step
-					if (!configStep || status == 1
-							|| (!oneSkippedOrNotApplicableConfigStepRecorded && status == 2 || status == 3)) {
-						final long testStepStartTimestamp = getStartTimestamp(testStep);
-						final String testStepId = getItemID(testStep);
-						resultCollector.startTestStep(testStepId, testStepStartTimestamp);
+                    // output only failed steps or only one skipped or not applicable config test step
+                    if (!configStep || status == 1
+                            || (!oneSkippedOrNotApplicableConfigStepRecorded && status == 2 || status == 3)) {
+                        final long testStepStartTimestamp = getStartTimestamp(testStep);
+                        final String testStepId = getItemID(testStep);
+                        resultCollector.startTestStep(testStepId, testStepStartTimestamp);
 
-						final String message = getMessage(testStep);
-						if (!SUtils.isNullOrEmpty(message)) {
-							resultCollector.addMessage("TR.teamEngineError", "error", message);
-						}
+                        final String message = getMessage(testStep);
+                        if (!SUtils.isNullOrEmpty(message)) {
+                            resultCollector.addMessage("TR.teamEngineError", "error", message);
+                        }
 
-						// Attachments
-						for (Node attachments = XmlUtils.getFirstChildNodeOfType(testStep, ELEMENT_NODE,
-								"attributes"); attachments != null; attachments = XmlUtils.getNextSiblingOfType(attachments,
-										ELEMENT_NODE, "attributes")) {
-							for (Node attachment = XmlUtils.getFirstChildNodeOfType(attachments, ELEMENT_NODE,
-									"attribute"); attachment != null; attachment = XmlUtils.getNextSiblingOfType(attachment,
-											ELEMENT_NODE, "attribute")) {
-								final String type = XmlUtils.getAttribute(attachment, "name");
-								switch (type) {
-								case "response":
-									final String response = XmlUtils.nodeValue(attachment);
-									resultCollector.saveAttachment(IOUtils.toInputStream(
-											response, "UTF-8"), "Service Response",
-											XmlUtils.isWellFormed(response) ? "text/xml" : null,
-											"ServiceResponse");
-									break;
-								case "request":
-									final String request = XmlUtils.nodeValue(attachment);
-									if (XmlUtils.isWellFormed(request)) {
-										resultCollector.saveAttachment(IOUtils.toInputStream(
-												XmlUtils.nodeValue(attachment), "UTF-8"), "Request Parameter", "text/xml",
-												"PostData");
-									} else {
-										resultCollector.saveAttachment(XmlUtils.nodeValue(attachment), "Request Parameter",
-												"text/plain",
-												"GetParameter");
-									}
-									break;
-								default:
-									resultCollector.saveAttachment(XmlUtils.nodeValue(attachment), type, null, type);
-								}
-							}
-						}
-						resultCollector.end(testStepId, status, testStepEndTimestamp);
-						if (configStep && (status == 2 || status == 3)) {
-							oneSkippedOrNotApplicableConfigStepRecorded = true;
-						}
-						testStepResultCollected = true;
-					}
-				}
-				if (testStepResultCollected) {
-					resultCollector.end(testCaseId, testCaseEndTimeStamp);
-				} else {
-					// only passed config steps collected,
-					resultCollector.end(testCaseId, 0, testCaseEndTimeStamp);
-				}
-			}
-			resultCollector.end(testModuleId, getEndTimestamp(testModule));
-		}
-		resultCollector.end(testTaskDto.getId().getId(), getEndTimestamp(suiteResult));
-	}
+                        // Attachments
+                        for (Node attachments = XmlUtils.getFirstChildNodeOfType(testStep, ELEMENT_NODE,
+                                "attributes"); attachments != null; attachments = XmlUtils.getNextSiblingOfType(attachments,
+                                        ELEMENT_NODE, "attributes")) {
+                            for (Node attachment = XmlUtils.getFirstChildNodeOfType(attachments, ELEMENT_NODE,
+                                    "attribute"); attachment != null; attachment = XmlUtils.getNextSiblingOfType(attachment,
+                                            ELEMENT_NODE, "attribute")) {
+                                final String type = XmlUtils.getAttribute(attachment, "name");
+                                switch (type) {
+                                case "response":
+                                    final String response = XmlUtils.nodeValue(attachment);
+                                    resultCollector.saveAttachment(IOUtils.toInputStream(
+                                            response, "UTF-8"), "Service Response",
+                                            XmlUtils.isWellFormed(response) ? "text/xml" : null,
+                                            "ServiceResponse");
+                                    break;
+                                case "request":
+                                    final String request = XmlUtils.nodeValue(attachment);
+                                    if (XmlUtils.isWellFormed(request)) {
+                                        resultCollector.saveAttachment(IOUtils.toInputStream(
+                                                XmlUtils.nodeValue(attachment), "UTF-8"), "Request Parameter", "text/xml",
+                                                "PostData");
+                                    } else {
+                                        resultCollector.saveAttachment(XmlUtils.nodeValue(attachment), "Request Parameter",
+                                                "text/plain",
+                                                "GetParameter");
+                                    }
+                                    break;
+                                default:
+                                    resultCollector.saveAttachment(XmlUtils.nodeValue(attachment), type, null, type);
+                                }
+                            }
+                        }
+                        resultCollector.end(testStepId, status, testStepEndTimestamp);
+                        if (configStep && (status == 2 || status == 3)) {
+                            oneSkippedOrNotApplicableConfigStepRecorded = true;
+                        }
+                        testStepResultCollected = true;
+                    }
+                }
+                if (testStepResultCollected) {
+                    resultCollector.end(testCaseId, testCaseEndTimeStamp);
+                } else {
+                    // only passed config steps collected,
+                    resultCollector.end(testCaseId, 0, testCaseEndTimeStamp);
+                }
+            }
+            resultCollector.end(testModuleId, getEndTimestamp(testModule));
+        }
+        resultCollector.end(testTaskDto.getId().getId(), getEndTimestamp(suiteResult));
+    }
 
-	private String getAssertionID(final Node node) {
-		return EidFactory.getDefault().createUUID(
-				etsSpecificPrefix +
-						XmlUtils.getAttribute(node.getParentNode(), "name") +
-						XmlUtils.getAttribute(node, "name") + "Assertion")
-				.getId();
-	}
+    private String getAssertionID(final Node node) {
+        return EidFactory.getDefault().createUUID(
+                etsSpecificPrefix +
+                        XmlUtils.getAttribute(node.getParentNode(), "name") +
+                        XmlUtils.getAttribute(node, "name") + "Assertion")
+                .getId();
+    }
 
-	private String getItemID(final Node node) {
-		return EidFactory.getDefault().createUUID(
-				etsSpecificPrefix +
-						XmlUtils.getAttribute(node.getParentNode(), "name") +
-						XmlUtils.getAttribute(node, "name"))
-				.getId();
-	}
+    private String getItemID(final Node node) {
+        return EidFactory.getDefault().createUUID(
+                etsSpecificPrefix +
+                        XmlUtils.getAttribute(node.getParentNode(), "name") +
+                        XmlUtils.getAttribute(node, "name"))
+                .getId();
+    }
 
-	private long getStartTimestamp(final Node node) {
-		return TimeUtils.string8601ToDate(XmlUtils.getAttribute(node,
-				"started-at")).getTime();
-	}
+    private long getStartTimestamp(final Node node) {
+        return TimeUtils.string8601ToDate(XmlUtils.getAttribute(node,
+                "started-at")).getTime();
+    }
 
-	private long getEndTimestamp(final Node node) {
-		return TimeUtils.string8601ToDate(XmlUtils.getAttribute(node,
-				"finished-at")).getTime();
-	}
+    private long getEndTimestamp(final Node node) {
+        return TimeUtils.string8601ToDate(XmlUtils.getAttribute(node,
+                "finished-at")).getTime();
+    }
 
-	private int mapStatus(final Node node) {
-		final String status = XmlUtils.getAttribute(node, "status");
-		switch (status) {
-		case "PASS":
-			return 0;
-		case "FAIL":
-			// if the failed test is a config step which has an AssertionError exception, it is just NOT APPLICABLE
-			if ("true".equals(XmlUtils.getAttributeOrDefault(node, "is-config", "false"))) {
-				final Node exception = XmlUtils.getFirstChildNodeOfType(node, ELEMENT_NODE, "exception");
-				final String exceptionClass = XmlUtils.getAttribute(exception, "class");
-				if (exceptionClass != null && exceptionClass.equalsIgnoreCase("java.lang.AssertionError")) {
-					// NOT APPLICABLE
-					return 3;
-				}
-			}
-			// FAILED
-			return 1;
-		case "SKIP":
-			// if the skipped test has a SkipException, it is just NOT APPLICABLE
-			final Node exception = XmlUtils.getFirstChildNodeOfType(node, ELEMENT_NODE, "exception");
-			if (exception != null) {
-				final String exceptionClass = XmlUtils.getAttribute(exception, "class");
-				if (exceptionClass != null && !exceptionClass.equalsIgnoreCase("org.testng.SkipException")) {
-					// SKIPPED
-					return 2;
-				}
-			}
-			// NOT APPLICABLE
-			return 3;
-		}
-		// UNDEFINED
-		return 6;
-	}
+    private int mapStatus(final Node node) {
+        final String status = XmlUtils.getAttribute(node, "status");
+        switch (status) {
+        case "PASS":
+            return 0;
+        case "FAIL":
+            // if the failed test is a config step which has an AssertionError exception, it is just NOT APPLICABLE
+            if ("true".equals(XmlUtils.getAttributeOrDefault(node, "is-config", "false"))) {
+                final Node exception = XmlUtils.getFirstChildNodeOfType(node, ELEMENT_NODE, "exception");
+                final String exceptionClass = XmlUtils.getAttribute(exception, "class");
+                if (exceptionClass != null && exceptionClass.equalsIgnoreCase("java.lang.AssertionError")) {
+                    // NOT APPLICABLE
+                    return 3;
+                }
+            }
+            // FAILED
+            return 1;
+        case "SKIP":
+            // if the skipped test has a SkipException, it is just NOT APPLICABLE
+            final Node exception = XmlUtils.getFirstChildNodeOfType(node, ELEMENT_NODE, "exception");
+            if (exception != null) {
+                final String exceptionClass = XmlUtils.getAttribute(exception, "class");
+                if (exceptionClass != null && !exceptionClass.equalsIgnoreCase("org.testng.SkipException")) {
+                    // SKIPPED
+                    return 2;
+                }
+            }
+            // NOT APPLICABLE
+            return 3;
+        }
+        // UNDEFINED
+        return 6;
+    }
 
-	private String getMessage(final Node node) {
-		final Node exception = XmlUtils.getFirstChildNodeOfType(node, ELEMENT_NODE, "exception");
-		if (exception != null) {
-			final Node message = XmlUtils.getFirstChildNodeOfType(exception, ELEMENT_NODE, "message");
-			if (message != null) {
-				final String msg = XmlUtils.nodeValue(message);
-				if (!SUtils.isNullOrEmpty(msg)) {
-					return msg;
-				}
-			} else {
-				final String exceptionClass = XmlUtils.getAttribute(exception, "class");
-				if (!SUtils.isNullOrEmpty(exceptionClass)) {
-					return "No message provided. Exception class " + exceptionClass;
-				}
-			}
-		}
-		return null;
-	}
+    private String getMessage(final Node node) {
+        final Node exception = XmlUtils.getFirstChildNodeOfType(node, ELEMENT_NODE, "exception");
+        if (exception != null) {
+            final Node message = XmlUtils.getFirstChildNodeOfType(exception, ELEMENT_NODE, "message");
+            if (message != null) {
+                final String msg = XmlUtils.nodeValue(message);
+                if (!SUtils.isNullOrEmpty(msg)) {
+                    return msg;
+                }
+            } else {
+                final String exceptionClass = XmlUtils.getAttribute(exception, "class");
+                if (!SUtils.isNullOrEmpty(exceptionClass)) {
+                    return "No message provided. Exception class " + exceptionClass;
+                }
+            }
+        }
+        return null;
+    }
 
-	@Override
-	protected void doInit() throws ConfigurationException, InitializationException {
-		try {
-			// nothing to init
-		} catch (Exception e) {
-			throw new ExecutableTestSuiteUnavailable(testTaskDto.getExecutableTestSuite(), e);
-		}
-	}
+    @Override
+    protected void doInit() throws ConfigurationException, InitializationException {
+        try {
+            // nothing to init
+        } catch (Exception e) {
+            throw new ExecutableTestSuiteUnavailable(testTaskDto.getExecutableTestSuite(), e);
+        }
+    }
 
-	@Override
-	public void doRelease() {
-		// nothing to release
-	}
+    @Override
+    public void doRelease() {
+        // nothing to release
+    }
 
-	@Override
-	protected void doCancel() throws InvalidStateTransitionException {
-		// no background threads
-	}
+    @Override
+    protected void doCancel() throws InvalidStateTransitionException {
+        // no background threads
+    }
 }

--- a/src/main/java/de/interactive_instruments/etf/testdriver/te/TeTestTaskProgress.java
+++ b/src/main/java/de/interactive_instruments/etf/testdriver/te/TeTestTaskProgress.java
@@ -26,11 +26,11 @@ import de.interactive_instruments.etf.testdriver.AbstractTestTaskProgress;
  */
 class TeTestTaskProgress extends AbstractTestTaskProgress {
 
-	TeTestTaskProgress() {
-		initMaxSteps(4);
-	}
+    TeTestTaskProgress() {
+        initMaxSteps(4);
+    }
 
-	void stepCompleted() {
-		advance();
-	}
+    void stepCompleted() {
+        advance();
+    }
 }

--- a/src/main/java/de/interactive_instruments/etf/testdriver/te/TeTypeLoader.java
+++ b/src/main/java/de/interactive_instruments/etf/testdriver/te/TeTypeLoader.java
@@ -65,352 +65,341 @@ import de.interactive_instruments.properties.ConfigPropertyHolder;
  */
 class TeTypeLoader implements EtsTypeLoader {
 
-	// Supported Test Object Types
+    // Supported Test Object Types
 
-	private final static String suitesPath = "rest/suites";
-	private final static Set<String> whiteListEts = new HashSet<String>() {
-		{
-			add("WFS 2.0 (OGC 09-025r2/ISO 19142) Conformance Test Suite");
-		}
-	};
+    private final static String suitesPath = "rest/suites";
+    private final static Set<String> whiteListEts = new HashSet<String>() {
+        {
+            add("WFS 2.0 (OGC 09-025r2/ISO 19142) Conformance Test Suite");
+        }
+    };
 
-	private final ConfigProperties configProperties = new ConfigProperties();
-	private final URI apiUri;
-	private final Credentials credentials;
-	private final ComponentInfo driverInfo;
-	private final Logger logger = LoggerFactory.getLogger(TeTypeLoader.class);
-	private final Dao<ExecutableTestSuiteDto> etsDao;
-	private final DataStorage dataStorageCallback;
-	private final static String NOTE = "<br/><br/> This Executable Test Suite is executed using a remote TEAM Engine instance hosted by OGC for "
-			+ "their Compliance Program (CITE). The results are transformed into the ETF internal report format. Some information that is "
-			+ "typically included in ETF test results is not included in the TEAM Engine reports and cannot be included in this test report."
-			+ "<br/><br/>"
-			+ "Please report any issues or problems with the OGC CITE tests in the "
-			+ "<a target=\"_blank\" href=\"https://cite.opengeospatial.org/forum\">OGC Compliance Forum</a>.";
+    private final ConfigProperties configProperties = new ConfigProperties();
+    private final URI apiUri;
+    private final Credentials credentials;
+    private final ComponentInfo driverInfo;
+    private final Logger logger = LoggerFactory.getLogger(TeTypeLoader.class);
+    private final Dao<ExecutableTestSuiteDto> etsDao;
+    private final DataStorage dataStorageCallback;
+    private final static String NOTE = "<br/><br/> This Executable Test Suite is executed using a remote TEAM Engine instance hosted by OGC for "
+            + "their Compliance Program (CITE). The results are transformed into the ETF internal report format. Some information that is "
+            + "typically included in ETF test results is not included in the TEAM Engine reports and cannot be included in this test report."
+            + "<br/><br/>"
+            + "Please report any issues or problems with the OGC CITE tests in the "
+            + "<a target=\"_blank\" href=\"https://cite.opengeospatial.org/forum\">OGC Compliance Forum</a>.";
 
-	public static final TranslationTemplateBundleDto TE_TRANSLATION_TEMPLATE_BUNDLE = createTranslationTemplateBundle();
-	private boolean initialized = false;
-	private final EidHolderMap<ExecutableTestSuiteDto> propagatedDtos = new DefaultEidHolderMap<>();
-	private ExecutableTestSuiteLifeCycleListener mediator;
+    public static final TranslationTemplateBundleDto TE_TRANSLATION_TEMPLATE_BUNDLE = createTranslationTemplateBundle();
+    private boolean initialized = false;
+    private final EidHolderMap<ExecutableTestSuiteDto> propagatedDtos = new DefaultEidHolderMap<>();
+    private ExecutableTestSuiteLifeCycleListener mediator;
 
-	private static TranslationTemplateBundleDto createTranslationTemplateBundle() {
-		final TranslationTemplateBundleDto translationTemplateBundle = new TranslationTemplateBundleDto();
-		translationTemplateBundle.setId(EidFactory.getDefault().createAndPreserveStr("62605758-f4ab-4ad8-9091-bde90467ecdd"));
-		translationTemplateBundle.setSource(URI.create("library://etf-tetd"));
-		final List<TranslationTemplateDto> translationTemplateDtos = new ArrayList<TranslationTemplateDto>() {
-			{
-				final TranslationTemplateDto template1En = new TranslationTemplateDto(
-						"TR.teamEngineError", Locale.ENGLISH.toLanguageTag(),
-						"OGC TEAM Engine reported a failed test: {error}");
-				final TranslationTemplateDto template1De = new TranslationTemplateDto(
-						"TR.teamEngineError", Locale.GERMAN.toLanguageTag(),
-						"Die OGC TEAM Engine hat folgenden Fehler gemeldet: {error}");
-				add(template1En);
-				add(template1De);
-			}
-		};
-		translationTemplateBundle.addTranslationTemplates(translationTemplateDtos);
-		return translationTemplateBundle;
-	}
+    private static TranslationTemplateBundleDto createTranslationTemplateBundle() {
+        final TranslationTemplateBundleDto translationTemplateBundle = new TranslationTemplateBundleDto();
+        translationTemplateBundle.setId(EidFactory.getDefault().createAndPreserveStr("62605758-f4ab-4ad8-9091-bde90467ecdd"));
+        translationTemplateBundle.setSource(URI.create("library://etf-tetd"));
+        final List<TranslationTemplateDto> translationTemplateDtos = new ArrayList<TranslationTemplateDto>() {
+            {
+                final TranslationTemplateDto template1En = new TranslationTemplateDto(
+                        "TR.teamEngineError", Locale.ENGLISH.toLanguageTag(),
+                        "OGC TEAM Engine reported a failed test: {error}");
+                final TranslationTemplateDto template1De = new TranslationTemplateDto(
+                        "TR.teamEngineError", Locale.GERMAN.toLanguageTag(),
+                        "Die OGC TEAM Engine hat folgenden Fehler gemeldet: {error}");
+                add(template1En);
+                add(template1De);
+            }
+        };
+        translationTemplateBundle.addTranslationTemplates(translationTemplateDtos);
+        return translationTemplateBundle;
+    }
 
-	@Override
-	public ExecutableTestSuiteDto getExecutableTestSuiteById(final EID eid) {
-		return propagatedDtos.get(eid);
-	}
+    @Override
+    public ExecutableTestSuiteDto getExecutableTestSuiteById(final EID eid) {
+        return propagatedDtos.get(eid);
+    }
 
-	@Override
-	public void setLifeCycleListener(final ExecutableTestSuiteLifeCycleListener mediator) {
-		this.mediator = mediator;
-	}
+    @Override
+    public void setLifeCycleListener(final ExecutableTestSuiteLifeCycleListener mediator) {
+        this.mediator = mediator;
+    }
 
-	private void addEts(final ExecutableTestSuiteDto ets) {
-		propagatedDtos.add(ets);
-		if (this.mediator != null) {
-			this.mediator.lifeCycleChange(this, ExecutableTestSuiteLifeCycleListener.EventType.CREATED,
-					DefaultEidHolderMap.singleton(ets));
-		}
-	}
+    private void addEts(final ExecutableTestSuiteDto ets) {
+        propagatedDtos.add(ets);
+        if (this.mediator != null) {
+            this.mediator.lifeCycleChange(this, ExecutableTestSuiteLifeCycleListener.EventType.CREATED,
+                    DefaultEidHolderMap.singleton(ets));
+        }
+    }
 
-	@Override
-	public EidSet<? extends Dto> getTypes() {
-		return propagatedDtos.toSet();
-	}
+    @Override
+    public EidSet<? extends Dto> getTypes() {
+        return propagatedDtos.toSet();
+    }
 
-	@Override
-	public void release() {
-		propagatedDtos.clear();
-	}
+    @Override
+    public void release() {
+        propagatedDtos.clear();
+    }
 
-	private static class TeTypeBuilder implements TypeBuildingFileVisitor.TypeBuilder<ExecutableTestSuiteDto> {
+    private static class TeTypeBuilder implements TypeBuildingFileVisitor.TypeBuilder<ExecutableTestSuiteDto> {
 
-		@Override
-		public TypeBuildingFileVisitor.TypeBuilderCmd<ExecutableTestSuiteDto> prepare(final Path path) {
-			return null;
-		}
-	}
+        @Override
+        public TypeBuildingFileVisitor.TypeBuilderCmd<ExecutableTestSuiteDto> prepare(final Path path) {
+            return null;
+        }
+    }
 
-	/**
-	 * Default constructor.
-	 */
-	public TeTypeLoader(final DataStorage dataStorageCallback, final URI apiUri,
-			final Credentials credentials, final ComponentInfo driverInfo) {
-		this.apiUri = apiUri;
-		this.credentials = credentials;
-		this.driverInfo = driverInfo;
-		this.dataStorageCallback = dataStorageCallback;
-		this.etsDao = dataStorageCallback.getDao(ExecutableTestSuiteDto.class);
-	}
+    /**
+     * Default constructor.
+     */
+    public TeTypeLoader(final DataStorage dataStorageCallback, final URI apiUri,
+            final Credentials credentials, final ComponentInfo driverInfo) {
+        this.apiUri = apiUri;
+        this.credentials = credentials;
+        this.driverInfo = driverInfo;
+        this.dataStorageCallback = dataStorageCallback;
+        this.etsDao = dataStorageCallback.getDao(ExecutableTestSuiteDto.class);
+    }
 
-	@Override
-	public void init() throws ConfigurationException, InitializationException, InvalidStateTransitionException {
-		if (initialized == true) {
-			throw new InvalidStateTransitionException("Already initialized");
-		}
+    @Override
+    public void init() throws ConfigurationException, InitializationException, InvalidStateTransitionException {
+        if (initialized == true) {
+            throw new InvalidStateTransitionException("Already initialized");
+        }
 
-		this.configProperties.expectAllRequiredPropertiesSet();
+        this.configProperties.expectAllRequiredPropertiesSet();
 
-		// First propagate static types
-		final WriteDao<TestItemTypeDto> testItemTypeDao = ((WriteDao<TestItemTypeDto>) dataStorageCallback
-				.getDao(TestItemTypeDto.class));
-		try {
-			testItemTypeDao.deleteAllExisting(TE_TEST_ITEM_TYPES.keySet());
-			testItemTypeDao.addAll(TE_TEST_ITEM_TYPES.values());
-		} catch (final StorageException e) {
-			try {
-				testItemTypeDao.deleteAllExisting(TE_TEST_ITEM_TYPES.keySet());
-			} catch (StorageException ign) {
-				ExcUtils.suppress(ign);
-			}
-			throw new InitializationException(e);
-		}
-		final WriteDao<TranslationTemplateBundleDto> translationTemplateBundleDao = ((WriteDao<TranslationTemplateBundleDto>) dataStorageCallback
-				.getDao(TranslationTemplateBundleDto.class));
-		try {
-			translationTemplateBundleDao.deleteAllExisting(Collections.singleton(TE_TRANSLATION_TEMPLATE_BUNDLE.getId()));
-			translationTemplateBundleDao.add(TE_TRANSLATION_TEMPLATE_BUNDLE);
-		} catch (final StorageException e) {
-			try {
-				translationTemplateBundleDao.deleteAllExisting(Collections.singleton(TE_TRANSLATION_TEMPLATE_BUNDLE.getId()));
-			} catch (StorageException ign) {
-				ExcUtils.suppress(ign);
-			}
-			throw new InitializationException(e);
-		}
-		final WriteDao<TagDto> tagDao = ((WriteDao<TagDto>) dataStorageCallback
-				.getDao(TagDto.class));
-		try {
-			tagDao.deleteAllExisting(Collections.singleton(TE_TEAM_ENGINE_TAG.getId()));
-			tagDao.add(TE_TEAM_ENGINE_TAG);
-		} catch (final StorageException e) {
-			try {
-				tagDao.deleteAllExisting(Collections.singleton(TE_TEAM_ENGINE_TAG.getId()));
-			} catch (StorageException ign) {
-				ExcUtils.suppress(ign);
-			}
-			throw new InitializationException(e);
-		}
+        // First propagate static types
+        final WriteDao<TestItemTypeDto> testItemTypeDao = ((WriteDao<TestItemTypeDto>) dataStorageCallback
+                .getDao(TestItemTypeDto.class));
+        try {
+            testItemTypeDao.deleteAllExisting(TE_TEST_ITEM_TYPES.keySet());
+            testItemTypeDao.addAll(TE_TEST_ITEM_TYPES.values());
+        } catch (final StorageException e) {
+            try {
+                testItemTypeDao.deleteAllExisting(TE_TEST_ITEM_TYPES.keySet());
+            } catch (StorageException ign) {
+                ExcUtils.suppress(ign);
+            }
+            throw new InitializationException(e);
+        }
+        final WriteDao<TranslationTemplateBundleDto> translationTemplateBundleDao = ((WriteDao<TranslationTemplateBundleDto>) dataStorageCallback
+                .getDao(TranslationTemplateBundleDto.class));
+        try {
+            translationTemplateBundleDao.deleteAllExisting(Collections.singleton(TE_TRANSLATION_TEMPLATE_BUNDLE.getId()));
+            translationTemplateBundleDao.add(TE_TRANSLATION_TEMPLATE_BUNDLE);
+        } catch (final StorageException e) {
+            try {
+                translationTemplateBundleDao.deleteAllExisting(Collections.singleton(TE_TRANSLATION_TEMPLATE_BUNDLE.getId()));
+            } catch (StorageException ign) {
+                ExcUtils.suppress(ign);
+            }
+            throw new InitializationException(e);
+        }
+        final WriteDao<TagDto> tagDao = ((WriteDao<TagDto>) dataStorageCallback
+                .getDao(TagDto.class));
+        try {
+            tagDao.deleteAllExisting(Collections.singleton(TE_TEAM_ENGINE_TAG.getId()));
+            tagDao.add(TE_TEAM_ENGINE_TAG);
+        } catch (final StorageException e) {
+            try {
+                tagDao.deleteAllExisting(Collections.singleton(TE_TEAM_ENGINE_TAG.getId()));
+            } catch (StorageException ign) {
+                ExcUtils.suppress(ign);
+            }
+            throw new InitializationException(e);
+        }
 
-		final List<ExecutableTestSuiteDto> eTestSuitesToAdd = initEts();
-		for (final ExecutableTestSuiteDto ets : eTestSuitesToAdd) {
-			try {
-				if (!etsDao.exists(ets.getId()) || etsDao.isDisabled(ets.getId())) {
-					((WriteDao<ExecutableTestSuiteDto>) etsDao).add(ets);
-				}
-			} catch (StorageException e) {
-				throw new InitializationException("Could not add/update ETS: ", e);
-			}
-		}
+        final List<ExecutableTestSuiteDto> eTestSuitesToAdd = initEts();
+        for (final ExecutableTestSuiteDto ets : eTestSuitesToAdd) {
+            try {
+                if (!etsDao.exists(ets.getId()) || etsDao.isDisabled(ets.getId())) {
+                    ((WriteDao<ExecutableTestSuiteDto>) etsDao).add(ets);
+                }
+            } catch (StorageException e) {
+                throw new InitializationException("Could not add/update ETS: ", e);
+            }
+        }
 
-		this.initialized = true;
-	}
+        this.initialized = true;
+    }
 
-	@Override
-	public final boolean isInitialized() {
-		return this.initialized;
-	}
+    @Override
+    public final boolean isInitialized() {
+        return this.initialized;
+    }
 
-	private List<ExecutableTestSuiteDto> initEts() throws InitializationException {
-		// Check if URL returns 404
-		final URI suitesUri;
-		try {
-			suitesUri = new URI(apiUri.toString() + suitesPath);
-		} catch (URISyntaxException e) {
-			throw new InitializationException("Invalid URL", e);
-		}
-		if (!UriUtils.exists(suitesUri, credentials)) {
-			throw new InitializationException("TEAM Engine application web interface not available at " + suitesUri.toString());
-		}
+    private List<ExecutableTestSuiteDto> initEts() throws InitializationException {
+        // Check if URL returns 404
+        final URI suitesUri;
+        try {
+            suitesUri = new URI(apiUri.toString() + suitesPath);
+        } catch (URISyntaxException e) {
+            throw new InitializationException("Invalid URL", e);
+        }
+        if (!UriUtils.exists(suitesUri, credentials)) {
+            throw new InitializationException("TEAM Engine application web interface not available at " + suitesUri.toString());
+        }
 
-		// TODO update mechanism:
-		// get already installed ETS
-		// - check if remoteURL is available
-		// - compare label and version information with new fetched ETSs
+        // TODO update mechanism:
+        // get already installed ETS
+        // - check if remoteURL is available
+        // - compare label and version information with new fetched ETSs
 
-		try {
-			// Get list of Executable Test Suites
-			final String etsOverview = UriUtils.loadAsString(suitesUri, credentials);
-			final Document etsOverviewDoc = Jsoup.parse(etsOverview);
-			final Elements etsUrls = etsOverviewDoc.select("body ul li a[href]");
-			for (final Element etsUrl : etsUrls) {
-				// Get single ETS
-				final String etsDetails;
-				final String etsUrlStr = UriUtils.getParent(suitesUri).toString() + etsUrl.attr("href");
-				try {
-					etsDetails = UriUtils.loadAsString(new URI(etsUrlStr), credentials);
-				} catch (URISyntaxException e) {
-					logger.error("Invalid URL retrieved", e);
-					continue;
-				}
-				// Build pseudo ETS
-				final Document etsDetailsDoc = Jsoup.parse(etsDetails);
-				final String label = etsDetailsDoc.title();
-				if (!whiteListEts.contains(label)) {
-					logger.debug("Skipping non-whitelisted Executable Test Suite " + label);
-					continue;
-				} else {
-					logger.debug("Adding Executable Test Suite " + label);
-				}
-				ExecutableTestSuiteDto ets = new ExecutableTestSuiteDto();
-				ets.setLabel(label);
-				ets.setReference(etsUrlStr);
-				ets.setRemoteResource(URI.create(etsUrlStr));
-				// The ETS ID is generated from the URL without the version
-				final String etsUrlWithoutVersion = UriUtils.getParent(etsUrlStr);
-				ets.setId(EidFactory.getDefault().createUUID(etsUrlWithoutVersion));
-				ets.setVersionFromStr(UriUtils.lastSegment(etsUrlStr));
-				// Check if an ETS already exists and if the version matches
-				boolean create = true;
-				if (etsDao.exists(ets.getId())) {
-					try {
-						final ExecutableTestSuiteDto etsComp = etsDao.getById(ets.getId()).getDto();
-						if (etsComp.getVersion().equals(ets.getVersion())) {
-							// version match, no update required. Check if the ETS is deactivated and reactivate it.
-							ets = etsComp;
-							etsComp.setDisabled(false);
-							addEts(ets);
-							create = false;
-						}
-					} catch (ObjectWithIdNotFoundException | StorageException e) {
-						logger.error("Could not compare old ETS", e);
-					}
-				}
-				if (create) {
-					final Element descriptionEl = etsDetailsDoc.select("body p").first();
-					final String description = descriptionEl != null ? descriptionEl.text()
-							: "No description provided by OGC TEAM Engine";
-					ets.setDescription(description + NOTE);
-					ets.addTag(TE_TEAM_ENGINE_TAG);
-					ets.setItemHash(SUtils.fastCalcHashAsHexStr(description));
-					ets.setLastEditor("Open Geospatial Consortium");
-					ets.setLastUpdateDateNow();
-					ets.setTranslationTemplateBundle(TE_TRANSLATION_TEMPLATE_BUNDLE);
-					ets.setTestDriver(new ComponentDto(driverInfo));
-					ets.setSupportedTestObjectTypes(TE_SUPPORTED_TEST_OBJECT_TYPES.asList());
-					addEts(ets);
-				}
-			}
-			return propagatedDtos.asList();
-		} catch (final IOException e) {
-			throw new InitializationException("Could not retrieve Executable Test Suites with"
-					+ " TEAM Engine application web interface ", e);
-		}
-	}
+        try {
+            // Get list of Executable Test Suites
+            final String etsOverview = UriUtils.loadAsString(suitesUri, credentials);
+            final Document etsOverviewDoc = Jsoup.parse(etsOverview);
+            final Elements etsUrls = etsOverviewDoc.select("body ul li a[href]");
+            for (final Element etsUrl : etsUrls) {
+                // Get single ETS
+                final String etsDetails;
+                final String etsUrlStr = UriUtils.getParent(suitesUri).toString() + etsUrl.attr("href");
+                try {
+                    etsDetails = UriUtils.loadAsString(new URI(etsUrlStr), credentials);
+                } catch (URISyntaxException e) {
+                    logger.error("Invalid URL retrieved", e);
+                    continue;
+                }
+                // Build pseudo ETS
+                final Document etsDetailsDoc = Jsoup.parse(etsDetails);
+                final String label = etsDetailsDoc.title();
+                if (!whiteListEts.contains(label)) {
+                    logger.debug("Skipping non-whitelisted Executable Test Suite " + label);
+                    continue;
+                } else {
+                    logger.debug("Adding Executable Test Suite " + label);
+                }
+                ExecutableTestSuiteDto ets = new ExecutableTestSuiteDto();
+                ets.setLabel(label);
+                ets.setReference(etsUrlStr);
+                ets.setRemoteResource(URI.create(etsUrlStr));
+                // The ETS ID is generated from the URL without the version
+                final String etsUrlWithoutVersion = UriUtils.getParent(etsUrlStr);
+                ets.setId(EidFactory.getDefault().createUUID(etsUrlWithoutVersion));
+                ets.setVersionFromStr(UriUtils.lastSegment(etsUrlStr));
+                // Check if an ETS already exists and if the version matches
+                boolean create = true;
+                if (etsDao.exists(ets.getId())) {
+                    try {
+                        final ExecutableTestSuiteDto etsComp = etsDao.getById(ets.getId()).getDto();
+                        if (etsComp.getVersion().equals(ets.getVersion())) {
+                            // version match, no update required. Check if the ETS is deactivated and reactivate it.
+                            ets = etsComp;
+                            etsComp.setDisabled(false);
+                            addEts(ets);
+                            create = false;
+                        }
+                    } catch (ObjectWithIdNotFoundException | StorageException e) {
+                        logger.error("Could not compare old ETS", e);
+                    }
+                }
+                if (create) {
+                    final Element descriptionEl = etsDetailsDoc.select("body p").first();
+                    final String description = descriptionEl != null ? descriptionEl.text()
+                            : "No description provided by OGC TEAM Engine";
+                    ets.setDescription(description + NOTE);
+                    ets.addTag(TE_TEAM_ENGINE_TAG);
+                    ets.setItemHash(SUtils.fastCalcHashAsHexStr(description));
+                    ets.setLastEditor("Open Geospatial Consortium");
+                    ets.setLastUpdateDateNow();
+                    ets.setTranslationTemplateBundle(TE_TRANSLATION_TEMPLATE_BUNDLE);
+                    ets.setTestDriver(new ComponentDto(driverInfo));
+                    ets.setSupportedTestObjectTypes(TE_SUPPORTED_TEST_OBJECT_TYPES.asList());
+                    addEts(ets);
+                }
+            }
+            return propagatedDtos.asList();
+        } catch (final IOException e) {
+            throw new InitializationException("Could not retrieve Executable Test Suites with"
+                    + " TEAM Engine application web interface ", e);
+        }
+    }
 
-	boolean updateEtsFromResult(final ExecutableTestSuiteDto executableTestSuite, final org.w3c.dom.Document document)
-			throws ParseException, ObjectWithIdNotFoundException, StorageException {
+    boolean updateEtsFromResult(final ExecutableTestSuiteDto executableTestSuite, final org.w3c.dom.Document document)
+            throws ParseException, ObjectWithIdNotFoundException, StorageException {
 
-		// TODO parse ETS, compare hash, only update if nescessary
+        // TODO parse ETS, compare hash, only update if nescessary
 
-		final org.w3c.dom.Element result = document.getDocumentElement();
-		if (!"testng-results".equals(result.getNodeName())) {
-			throw new ParseException("Expected a TestNG result XML", document.getDocumentURI(), 0);
-		}
+        final org.w3c.dom.Element result = document.getDocumentElement();
+        if (!"testng-results".equals(result.getNodeName())) {
+            throw new ParseException("Expected a TestNG result XML", document.getDocumentURI(), 0);
+        }
 
-		final Node testSuite = XmlUtils.getFirstChildNodeOfType(result, ELEMENT_NODE, "suite");
-		final String etsSpecificPrefix = executableTestSuite.getId().getId() + executableTestSuite.getLabel();
+        final Node testSuite = XmlUtils.getFirstChildNodeOfType(result, ELEMENT_NODE, "suite");
+        final String etsSpecificPrefix = executableTestSuite.getId().getId() + executableTestSuite.getLabel();
 
-		final LangTranslationTemplateCollectionDto defaultErr = TE_TRANSLATION_TEMPLATE_BUNDLE
-				.getTranslationTemplateCollection("TR.teamEngineError");
-		final TestItemTypeDto testNgAsseriton = TE_TEST_ITEM_TYPES.get("161baae7-6c84-4bce-8185-3d3618a66011");
-		final TestItemTypeDto testNgStep = TE_TEST_ITEM_TYPES.get("b0469ab7-9d69-49ff-98a1-4c7960829b82");
+        final LangTranslationTemplateCollectionDto defaultErr = TE_TRANSLATION_TEMPLATE_BUNDLE
+                .getTranslationTemplateCollection("TR.teamEngineError");
+        final TestItemTypeDto testNgAsseriton = TE_TEST_ITEM_TYPES.get("161baae7-6c84-4bce-8185-3d3618a66011");
+        final TestItemTypeDto testNgStep = TE_TEST_ITEM_TYPES.get("b0469ab7-9d69-49ff-98a1-4c7960829b82");
 
-		// Test Modules
-		for (Node testModule = XmlUtils.getFirstChildNodeOfType(testSuite, ELEMENT_NODE,
-				"test"); testModule != null; testModule = XmlUtils.getNextSiblingOfType(testModule, ELEMENT_NODE, "test")) {
-			final EID testModuleId = getItemID(testModule, etsSpecificPrefix);
-			final TestModuleDto testModuleDto = new TestModuleDto();
-			testModuleDto.setId(testModuleId);
-			setDefaultProperties(testModule, testModuleDto);
-			testModuleDto.setParent(executableTestSuite);
+        // Test Modules
+        for (Node testModule = XmlUtils.getFirstChildNodeOfType(testSuite, ELEMENT_NODE,
+                "test"); testModule != null; testModule = XmlUtils.getNextSiblingOfType(testModule, ELEMENT_NODE, "test")) {
+            final EID testModuleId = getItemID(testModule, etsSpecificPrefix);
+            final TestModuleDto testModuleDto = new TestModuleDto();
+            testModuleDto.setId(testModuleId);
+            setDefaultProperties(testModule, testModuleDto);
+            testModuleDto.setParent(executableTestSuite);
 
-			// Test Cases
-			for (Node testCase = XmlUtils.getFirstChildNodeOfType(testModule, ELEMENT_NODE,
-					"class"); testCase != null; testCase = XmlUtils.getNextSiblingOfType(testCase, ELEMENT_NODE, "class")) {
-				final EID testCaseId = getItemID(testCase, etsSpecificPrefix);
-				final TestCaseDto testCaseDto = new TestCaseDto();
-				testCaseDto.setId(testCaseId);
-				setDefaultProperties(testCase, testCaseDto);
-				testCaseDto.setParent(testModuleDto);
+            // Test Cases
+            for (Node testCase = XmlUtils.getFirstChildNodeOfType(testModule, ELEMENT_NODE,
+                    "class"); testCase != null; testCase = XmlUtils.getNextSiblingOfType(testCase, ELEMENT_NODE, "class")) {
+                final EID testCaseId = getItemID(testCase, etsSpecificPrefix);
+                final TestCaseDto testCaseDto = new TestCaseDto();
+                testCaseDto.setId(testCaseId);
+                setDefaultProperties(testCase, testCaseDto);
+                testCaseDto.setParent(testModuleDto);
 
-				// Test Steps
-				for (Node testStep = XmlUtils.getFirstChildNodeOfType(testCase, ELEMENT_NODE,
-						"test-method"); testStep != null; testStep = XmlUtils.getNextSiblingOfType(testStep, ELEMENT_NODE,
-								"test-method")) {
-					final EID testStepId = getItemID(testStep, etsSpecificPrefix);
-					final TestStepDto testStepDto = new TestStepDto();
-					testStepDto.setId(testStepId);
-					setDefaultProperties(testStep, testStepDto);
-					testStepDto.setParent(testCaseDto);
-					testStepDto.setType(testNgStep);
-					testStepDto.setStatementForExecution("NOT_APPLICABLE");
+                // Test Steps
+                for (Node testStep = XmlUtils.getFirstChildNodeOfType(testCase, ELEMENT_NODE,
+                        "test-method"); testStep != null; testStep = XmlUtils.getNextSiblingOfType(testStep, ELEMENT_NODE,
+                                "test-method")) {
+                    final EID testStepId = getItemID(testStep, etsSpecificPrefix);
+                    final TestStepDto testStepDto = new TestStepDto();
+                    testStepDto.setId(testStepId);
+                    setDefaultProperties(testStep, testStepDto);
+                    testStepDto.setParent(testCaseDto);
+                    testStepDto.setType(testNgStep);
+                    testStepDto.setStatementForExecution("NOT_APPLICABLE");
 
-					// Pseudo Assertion
-					/*
-					final EID assertionId = getAssertionID(testStep, etsSpecificPrefix);
-					final TestAssertionDto assertionDto = new TestAssertionDto();
-					assertionDto.setId(assertionId);
-					setDefaultProperties(testStep, assertionDto);
-					assertionDto.setParent(testStepDto);
-					assertionDto.addTranslationTemplate(defaultErr);
-					assertionDto.setType(testNgAsseriton);
-					assertionDto.setExpectedResult("NOT_APPLICABLE");
-					assertionDto.setExpression("NOT_APPLICABLE");
-					testStepDto.addTestAssertion(assertionDto);
-					*/
-					testCaseDto.addTestStep(testStepDto);
-				}
-				testModuleDto.addTestCase(testCaseDto);
+                    // Pseudo Assertion
+                    /* final EID assertionId = getAssertionID(testStep, etsSpecificPrefix); final TestAssertionDto assertionDto = new TestAssertionDto(); assertionDto.setId(assertionId); setDefaultProperties(testStep, assertionDto); assertionDto.setParent(testStepDto); assertionDto.addTranslationTemplate(defaultErr); assertionDto.setType(testNgAsseriton); assertionDto.setExpectedResult("NOT_APPLICABLE"); assertionDto.setExpression("NOT_APPLICABLE"); testStepDto.addTestAssertion(assertionDto); */
+                    testCaseDto.addTestStep(testStepDto);
+                }
+                testModuleDto.addTestCase(testCaseDto);
 
-			}
-			executableTestSuite.addTestModule(testModuleDto);
-		}
-		propagatedDtos.add(executableTestSuite);
-		((WriteDao) etsDao).replace(executableTestSuite);
-		return true;
-	}
+            }
+            executableTestSuite.addTestModule(testModuleDto);
+        }
+        propagatedDtos.add(executableTestSuite);
+        ((WriteDao) etsDao).replace(executableTestSuite);
+        return true;
+    }
 
-	private EID getAssertionID(final Node node, final String etsSpecificPrefix) {
-		return EidFactory.getDefault().createUUID(
-				etsSpecificPrefix +
-						XmlUtils.getAttribute(node.getParentNode(), "name") +
-						XmlUtils.getAttribute(node, "name") + "Assertion");
-	}
+    private EID getAssertionID(final Node node, final String etsSpecificPrefix) {
+        return EidFactory.getDefault().createUUID(
+                etsSpecificPrefix +
+                        XmlUtils.getAttribute(node.getParentNode(), "name") +
+                        XmlUtils.getAttribute(node, "name") + "Assertion");
+    }
 
-	private EID getItemID(final Node node, final String etsSpecificPrefix) {
-		return EidFactory.getDefault().createUUID(
-				etsSpecificPrefix +
-						XmlUtils.getAttribute(node.getParentNode(), "name") +
-						XmlUtils.getAttribute(node, "name"));
-	}
+    private EID getItemID(final Node node, final String etsSpecificPrefix) {
+        return EidFactory.getDefault().createUUID(
+                etsSpecificPrefix +
+                        XmlUtils.getAttribute(node.getParentNode(), "name") +
+                        XmlUtils.getAttribute(node, "name"));
+    }
 
-	private void setDefaultProperties(final Node node, final TestModelItemDto dto) {
-		dto.setLabel(XmlUtils.getAttribute(node, "name"));
-		dto.setDescription(XmlUtils.getAttribute(node, "description"));
-	}
+    private void setDefaultProperties(final Node node, final TestModelItemDto dto) {
+        dto.setLabel(XmlUtils.getAttribute(node, "name"));
+        dto.setDescription(XmlUtils.getAttribute(node, "description"));
+    }
 
-	@Override
-	public ConfigPropertyHolder getConfigurationProperties() {
-		return configProperties;
-	}
+    @Override
+    public ConfigPropertyHolder getConfigurationProperties() {
+        return configProperties;
+    }
 
 }

--- a/src/main/java/de/interactive_instruments/etf/testdriver/te/TeTypeLoader.java
+++ b/src/main/java/de/interactive_instruments/etf/testdriver/te/TeTypeLoader.java
@@ -274,9 +274,21 @@ class TeTypeLoader implements EtsTypeLoader {
                 ets.setLabel(label);
                 ets.setReference(etsUrlStr);
                 ets.setRemoteResource(URI.create(etsUrlStr));
-                // The ETS ID is generated from the URL without the version
-                final String etsUrlWithoutVersion = UriUtils.getParent(etsUrlStr);
-                ets.setId(EidFactory.getDefault().createUUID(etsUrlWithoutVersion));
+                // The ETS ID is generated from the URL of the public Team Engine (without the version)
+                // to preserve dependencies declared on the imported test suites, regardless of where the
+                // Team Engine is deployed.
+                final URI suitesUriForId;
+                try {
+                    suitesUriForId = new URI("http://cite.opengeospatial.org/teamengine/" + suitesPath);
+                } catch (URISyntaxException e) {
+                    throw new InitializationException("Invalid URL", e);
+                }
+                final String etsUrlStrForId = UriUtils.getParent(suitesUriForId).toString() + etsUrl.attr("href");
+                final String etsUrlWithoutVersion = UriUtils.getParent(etsUrlStrForId);
+                logger.debug("ETS URL w/o version = {}", etsUrlWithoutVersion);
+                final EID etsId = EidFactory.getDefault().createUUID(etsUrlWithoutVersion);
+                logger.debug("UUID for Test Suite \"{}\": {}", label, etsId.toString());
+                ets.setId(etsId);
                 ets.setVersionFromStr(UriUtils.lastSegment(etsUrlStr));
                 // Check if an ETS already exists and if the version matches
                 boolean create = true;

--- a/src/main/java/de/interactive_instruments/etf/testdriver/te/Types.java
+++ b/src/main/java/de/interactive_instruments/etf/testdriver/te/Types.java
@@ -32,48 +32,48 @@ import de.interactive_instruments.etf.model.EidMap;
  */
 class Types {
 
-	private Types() {}
+    private Types() {}
 
-	// Supported Test Object Types
-	public static final EidMap<TestObjectTypeDto> TE_SUPPORTED_TEST_OBJECT_TYPES = TestObjectTypeDetectorManager
-			.getTypes(
-					// WFS_2_0_TOT
-					"9b6ef734-981e-4d60-aa81-d6730a1c6389");
+    // Supported Test Object Types
+    public static final EidMap<TestObjectTypeDto> TE_SUPPORTED_TEST_OBJECT_TYPES = TestObjectTypeDetectorManager
+            .getTypes(
+                    // WFS_2_0_TOT
+                    "9b6ef734-981e-4d60-aa81-d6730a1c6389");
 
-	// Supported Test Item Types
-	public static final EidMap<TestItemTypeDto> TE_TEST_ITEM_TYPES = new DefaultEidMap<TestItemTypeDto>() {
-		{
-			{
-				final TestItemTypeDto testItemTypeDto = new TestItemTypeDto();
-				testItemTypeDto.setLabel("TestNG Test Step");
-				testItemTypeDto.setId(EidFactory.getDefault().createAndPreserveStr("b0469ab7-9d69-49ff-98a1-4c7960829b82"));
-				testItemTypeDto.setDescription("TestNG Test Step");
-				testItemTypeDto.setReference(
-						"http://none");
-				put(testItemTypeDto.getId(), testItemTypeDto);
-			}
+    // Supported Test Item Types
+    public static final EidMap<TestItemTypeDto> TE_TEST_ITEM_TYPES = new DefaultEidMap<TestItemTypeDto>() {
+        {
+            {
+                final TestItemTypeDto testItemTypeDto = new TestItemTypeDto();
+                testItemTypeDto.setLabel("TestNG Test Step");
+                testItemTypeDto.setId(EidFactory.getDefault().createAndPreserveStr("b0469ab7-9d69-49ff-98a1-4c7960829b82"));
+                testItemTypeDto.setDescription("TestNG Test Step");
+                testItemTypeDto.setReference(
+                        "http://none");
+                put(testItemTypeDto.getId(), testItemTypeDto);
+            }
 
-			{
-				final TestItemTypeDto testItemTypeDto = new TestItemTypeDto();
-				testItemTypeDto.setLabel("TestNG Test Assertion set");
-				testItemTypeDto.setId(EidFactory.getDefault().createAndPreserveStr("161baae7-6c84-4bce-8185-3d3618a66011"));
-				testItemTypeDto.setDescription(
-						"Multiple TestNG assertions");
-				testItemTypeDto.setReference(
-						"http://none");
-				put(testItemTypeDto.getId(), testItemTypeDto);
-			}
-		}
-	};
+            {
+                final TestItemTypeDto testItemTypeDto = new TestItemTypeDto();
+                testItemTypeDto.setLabel("TestNG Test Assertion set");
+                testItemTypeDto.setId(EidFactory.getDefault().createAndPreserveStr("161baae7-6c84-4bce-8185-3d3618a66011"));
+                testItemTypeDto.setDescription(
+                        "Multiple TestNG assertions");
+                testItemTypeDto.setReference(
+                        "http://none");
+                put(testItemTypeDto.getId(), testItemTypeDto);
+            }
+        }
+    };
 
-	public static final TagDto TE_TEAM_ENGINE_TAG = createTeTag();
+    public static final TagDto TE_TEAM_ENGINE_TAG = createTeTag();
 
-	private static TagDto createTeTag() {
-		final TagDto tag = new TagDto();
-		tag.setId(EidFactory.getDefault().createUUID("268af871-5cf0-443e-834a-ce40bed6c0e3"));
-		tag.setPriority(1000);
-		tag.setLabel("OGC Test Suites (remote execution)");
-		tag.setDescription("Executable Test Suites that are executed on a remote OGC TEAM Engine instance");
-		return tag;
-	}
+    private static TagDto createTeTag() {
+        final TagDto tag = new TagDto();
+        tag.setId(EidFactory.getDefault().createUUID("268af871-5cf0-443e-834a-ce40bed6c0e3"));
+        tag.setPriority(1000);
+        tag.setLabel("OGC Test Suites (remote execution)");
+        tag.setDescription("Executable Test Suites that are executed on a remote OGC TEAM Engine instance");
+        return tag;
+    }
 }

--- a/src/test/java/de/interactive_instruments/etf/testdriver/te/TeTestRunTaskFactoryTest.java
+++ b/src/test/java/de/interactive_instruments/etf/testdriver/te/TeTestRunTaskFactoryTest.java
@@ -73,211 +73,211 @@ import de.interactive_instruments.properties.PropertyUtils;
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class TeTestRunTaskFactoryTest {
 
-	// DO NOT RUN THE TESTS IN THE IDE BUT WITH GRADLE
+    // DO NOT RUN THE TESTS IN THE IDE BUT WITH GRADLE
 
-	private static TestDriverManager testDriverManager = null;
-	private static DataStorage DATA_STORAGE = DataStorageTestUtils.inMemoryStorage();
+    private static TestDriverManager testDriverManager = null;
+    private static DataStorage DATA_STORAGE = DataStorageTestUtils.inMemoryStorage();
 
-	private final static String VERSION = "1.26";
-	private final static String LABEL = "WFS 2.0 (OGC 09-025r2/ISO 19142) Conformance Test Suite";
-	private final static EID wfs20EtsId = EidFactory.getDefault().createUUID(
-			"http://cite.opengeospatial.org/teamengine/rest/suites/wfs20/");
+    private final static String VERSION = "1.26";
+    private final static String LABEL = "WFS 2.0 (OGC 09-025r2/ISO 19142) Conformance Test Suite";
+    private final static EID wfs20EtsId = EidFactory.getDefault().createUUID(
+            "http://cite.opengeospatial.org/teamengine/rest/suites/wfs20/");
 
-	private static WriteDao<ExecutableTestSuiteDto> etsDao() {
-		return ((WriteDao) DATA_STORAGE.getDao(ExecutableTestSuiteDto.class));
-	}
+    private static WriteDao<ExecutableTestSuiteDto> etsDao() {
+        return ((WriteDao) DATA_STORAGE.getDao(ExecutableTestSuiteDto.class));
+    }
 
-	private TestRunDto createTestRunDtoForProject(final String url)
-			throws ComponentNotLoadedException, ConfigurationException, URISyntaxException,
-			StorageException, ObjectWithIdNotFoundException, IOException {
+    private TestRunDto createTestRunDtoForProject(final String url)
+            throws ComponentNotLoadedException, ConfigurationException, URISyntaxException,
+            StorageException, ObjectWithIdNotFoundException, IOException {
 
-		final TestObjectDto testObjectDto = new TestObjectDto();
-		testObjectDto.setId(
-				EidFactory.getDefault().createAndPreserveStr("fcfe9677-7b77-41dd-a17c-56884f60824f"));
-		testObjectDto.setLabel("Cite 2013 WFS");
-		final TestObjectTypeDto wfsTestObjectType = DATA_STORAGE.getDao(TestObjectTypeDto.class).getById(
-				EidFactory.getDefault().createAndPreserveStr("9b6ef734-981e-4d60-aa81-d6730a1c6389")).getDto();
-		testObjectDto.setTestObjectType(wfsTestObjectType);
-		testObjectDto.addResource(new ResourceDto("serviceEndpoint", url));
-		testObjectDto.setDescription("none");
-		testObjectDto.setVersionFromStr("1.0.0");
-		testObjectDto.setCreationDate(new Date(0));
-		testObjectDto.setAuthor("ii");
-		testObjectDto.setRemoteResource(URI.create("http://none"));
-		testObjectDto.setItemHash("");
-		testObjectDto.setLocalPath("/none");
+        final TestObjectDto testObjectDto = new TestObjectDto();
+        testObjectDto.setId(
+                EidFactory.getDefault().createAndPreserveStr("fcfe9677-7b77-41dd-a17c-56884f60824f"));
+        testObjectDto.setLabel("Cite 2013 WFS");
+        final TestObjectTypeDto wfsTestObjectType = DATA_STORAGE.getDao(TestObjectTypeDto.class).getById(
+                EidFactory.getDefault().createAndPreserveStr("9b6ef734-981e-4d60-aa81-d6730a1c6389")).getDto();
+        testObjectDto.setTestObjectType(wfsTestObjectType);
+        testObjectDto.addResource(new ResourceDto("serviceEndpoint", url));
+        testObjectDto.setDescription("none");
+        testObjectDto.setVersionFromStr("1.0.0");
+        testObjectDto.setCreationDate(new Date(0));
+        testObjectDto.setAuthor("ii");
+        testObjectDto.setRemoteResource(URI.create("http://none"));
+        testObjectDto.setItemHash("");
+        testObjectDto.setLocalPath("/none");
 
-		((WriteDao) DATA_STORAGE.getDao(TestObjectDto.class)).deleteAllExisting(Collections.singleton(testObjectDto.getId()));
-		((WriteDao) DATA_STORAGE.getDao(TestObjectDto.class)).add(testObjectDto);
+        ((WriteDao) DATA_STORAGE.getDao(TestObjectDto.class)).deleteAllExisting(Collections.singleton(testObjectDto.getId()));
+        ((WriteDao) DATA_STORAGE.getDao(TestObjectDto.class)).add(testObjectDto);
 
-		final ExecutableTestSuiteDto ets = DATA_STORAGE.getDao(ExecutableTestSuiteDto.class).getById(wfs20EtsId).getDto();
+        final ExecutableTestSuiteDto ets = DATA_STORAGE.getDao(ExecutableTestSuiteDto.class).getById(wfs20EtsId).getDto();
 
-		final TestTaskDto testTaskDto = new TestTaskDto();
-		testTaskDto.setId(EidFactory.getDefault().createAndPreserveStr("aa03825a-2f64-4e52-bdba-90a08adb80ce"));
-		testTaskDto.setExecutableTestSuite(ets);
-		testTaskDto.setTestObject(testObjectDto);
+        final TestTaskDto testTaskDto = new TestTaskDto();
+        testTaskDto.setId(EidFactory.getDefault().createAndPreserveStr("aa03825a-2f64-4e52-bdba-90a08adb80ce"));
+        testTaskDto.setExecutableTestSuite(ets);
+        testTaskDto.setTestObject(testObjectDto);
 
-		final TestRunDto testRunDto = new TestRunDto();
-		testRunDto.setDefaultLang("en");
-		testRunDto.setId(EidFactory.getDefault().createRandomId());
-		testRunDto.setLabel("Run label");
-		testRunDto.setStartTimestamp(new Date(0));
-		testRunDto.addTestTask(testTaskDto);
+        final TestRunDto testRunDto = new TestRunDto();
+        testRunDto.setDefaultLang("en");
+        testRunDto.setId(EidFactory.getDefault().createRandomId());
+        testRunDto.setLabel("Run label");
+        testRunDto.setStartTimestamp(new Date(0));
+        testRunDto.addTestTask(testTaskDto);
 
-		try {
-			((WriteDao) DATA_STORAGE.getDao(TestRunDto.class)).deleteAllExisting(Collections.singleton(testRunDto.getId()));
-		} catch (Exception e) {
-			ExcUtils.suppress(e);
-		}
-		return testRunDto;
-	}
+        try {
+            ((WriteDao) DATA_STORAGE.getDao(TestRunDto.class)).deleteAllExisting(Collections.singleton(testRunDto.getId()));
+        } catch (Exception e) {
+            ExcUtils.suppress(e);
+        }
+        return testRunDto;
+    }
 
-	@BeforeClass
-	public static void setUp()
-			throws IOException, ConfigurationException, InvalidStateTransitionException,
-			InitializationException, ObjectWithIdNotFoundException, StorageException {
+    @BeforeClass
+    public static void setUp()
+            throws IOException, ConfigurationException, InvalidStateTransitionException,
+            InitializationException, ObjectWithIdNotFoundException, StorageException {
 
-		// DO NOT RUN THE TESTS IN THE IDE BUT WITH GRADLE
+        // DO NOT RUN THE TESTS IN THE IDE BUT WITH GRADLE
 
-		// Init logger
-		LoggerFactory.getLogger(TeTestRunTaskFactoryTest.class).info("Started");
+        // Init logger
+        LoggerFactory.getLogger(TeTestRunTaskFactoryTest.class).info("Started");
 
-		if (DataStorageRegistry.instance().get(DATA_STORAGE.getClass().getName()) == null) {
-			DataStorageRegistry.instance().register(DATA_STORAGE);
-		}
+        if (DataStorageRegistry.instance().get(DATA_STORAGE.getClass().getName()) == null) {
+            DataStorageRegistry.instance().register(DATA_STORAGE);
+        }
 
-		if (testDriverManager == null) {
+        if (testDriverManager == null) {
 
-			// Delete old ETS
-			try {
-				etsDao().delete(wfs20EtsId);
-			} catch (final ObjectWithIdNotFoundException e) {
-				ExcUtils.suppress(e);
-			}
+            // Delete old ETS
+            try {
+                etsDao().delete(wfs20EtsId);
+            } catch (final ObjectWithIdNotFoundException e) {
+                ExcUtils.suppress(e);
+            }
 
-			final IFile tdDir = new IFile(PropertyUtils.getenvOrProperty(
-					"ETF_TD_DEPLOYMENT_DIR", "./build/tmp/td"));
-			tdDir.ensureDir();
-			tdDir.expectDirIsReadable();
+            final IFile tdDir = new IFile(PropertyUtils.getenvOrProperty(
+                    "ETF_TD_DEPLOYMENT_DIR", "./build/tmp/td"));
+            tdDir.ensureDir();
+            tdDir.expectDirIsReadable();
 
-			// Load driver
-			testDriverManager = new DefaultTestDriverManager();
-			testDriverManager.getConfigurationProperties().setProperty(
-					EtfConstants.ETF_TESTDRIVERS_DIR, tdDir.getAbsolutePath());
-			final IFile attachmentDir = new IFile(PropertyUtils.getenvOrProperty(
-					"ETF_DS_DIR", "./build/tmp/etf-ds")).secureExpandPathDown("attachments");
-			attachmentDir.deleteDirectory();
-			attachmentDir.mkdirs();
-			testDriverManager.getConfigurationProperties().setProperty(
-					EtfConstants.ETF_ATTACHMENT_DIR, attachmentDir.getAbsolutePath());
-			testDriverManager.getConfigurationProperties().setProperty(
-					EtfConstants.ETF_DATA_STORAGE_NAME,
-					DATA_STORAGE.getClass().getName());
+            // Load driver
+            testDriverManager = new DefaultTestDriverManager();
+            testDriverManager.getConfigurationProperties().setProperty(
+                    EtfConstants.ETF_TESTDRIVERS_DIR, tdDir.getAbsolutePath());
+            final IFile attachmentDir = new IFile(PropertyUtils.getenvOrProperty(
+                    "ETF_DS_DIR", "./build/tmp/etf-ds")).secureExpandPathDown("attachments");
+            attachmentDir.deleteDirectory();
+            attachmentDir.mkdirs();
+            testDriverManager.getConfigurationProperties().setProperty(
+                    EtfConstants.ETF_ATTACHMENT_DIR, attachmentDir.getAbsolutePath());
+            testDriverManager.getConfigurationProperties().setProperty(
+                    EtfConstants.ETF_DATA_STORAGE_NAME,
+                    DATA_STORAGE.getClass().getName());
 
-			testDriverManager.init();
-			testDriverManager.load(EidFactory.getDefault().createAndPreserveStr(TE_TEST_DRIVER_EID));
-		}
+            testDriverManager.init();
+            testDriverManager.load(EidFactory.getDefault().createAndPreserveStr(TE_TEST_DRIVER_EID));
+        }
 
-	}
+    }
 
-	@Test
-	public void T1_checkInitializedEts() throws Exception, ComponentNotLoadedException {
-		assertTrue(etsDao().available(wfs20EtsId));
+    @Test
+    public void T1_checkInitializedEts() throws Exception, ComponentNotLoadedException {
+        assertTrue(etsDao().available(wfs20EtsId));
 
-		final ExecutableTestSuiteDto ets = etsDao().getById(wfs20EtsId).getDto();
-		assertEquals(LABEL, ets.getLabel());
-		assertEquals(VERSION + ".0", ets.getVersionAsStr());
-		// Clean non-initialized ETS
-		assertEquals(0, ets.getLowestLevelItemSize());
-	}
+        final ExecutableTestSuiteDto ets = etsDao().getById(wfs20EtsId).getDto();
+        assertEquals(LABEL, ets.getLabel());
+        assertEquals(VERSION + ".0", ets.getVersionAsStr());
+        // Clean non-initialized ETS
+        assertEquals(0, ets.getLowestLevelItemSize());
+    }
 
-	@Test
-	public void T2_parseTestNgResults() throws Exception, ComponentNotLoadedException {
-		// Depends on testClasses (Classloader is not the test class loader so getResource does not work here)
-		final File file = new File("build/resources/test/response.xml");
+    @Test
+    public void T2_parseTestNgResults() throws Exception, ComponentNotLoadedException {
+        // Depends on testClasses (Classloader is not the test class loader so getResource does not work here)
+        final File file = new File("build/resources/test/response.xml");
 
-		final DocumentBuilderFactory domFactory = XmlUtils.newDocumentBuilderFactoryInstance();
-		domFactory.setNamespaceAware(true);
-		final DocumentBuilder builder = domFactory.newDocumentBuilder();
-		final Document result = builder.parse(file);
+        final DocumentBuilderFactory domFactory = XmlUtils.newDocumentBuilderFactoryInstance();
+        domFactory.setNamespaceAware(true);
+        final DocumentBuilder builder = domFactory.newDocumentBuilder();
+        final Document result = builder.parse(file);
 
-		final String testUrl = "https://services.interactive-instruments.de/cite-xs-46/simpledemo/cgi-bin/cities-postgresql/wfs?request=GetCapabilities&service=wfs";
-		final TestRunDto testRunDto = createTestRunDtoForProject(testUrl);
-		final TestRun testRun = testDriverManager.createTestRun(testRunDto);
-		final TestTask task = testRun.getTestTasks().get(0);
+        final String testUrl = "https://services.interactive-instruments.de/cite-xs-46/simpledemo/cgi-bin/cities-postgresql/wfs?request=GetCapabilities&service=wfs";
+        final TestRunDto testRunDto = createTestRunDtoForProject(testUrl);
+        final TestRun testRun = testDriverManager.createTestRun(testRunDto);
+        final TestTask task = testRun.getTestTasks().get(0);
 
-		final Method method = task.getClass().getDeclaredMethod("parseTestNgResult", Document.class);
-		method.setAccessible(true);
-		method.invoke(task, result);
-	}
+        final Method method = task.getClass().getDeclaredMethod("parseTestNgResult", Document.class);
+        method.setAccessible(true);
+        method.invoke(task, result);
+    }
 
-	@Test
-	public void T3_runTest() throws Exception, ComponentNotLoadedException {
+    @Test
+    public void T3_runTest() throws Exception, ComponentNotLoadedException {
 
-		final String testUrl = "https://services.interactive-instruments.de/cite-xs-46/simpledemo/cgi-bin/cities-postgresql/wfs?request=GetCapabilities&service=wfs";
-		TestRunDto testRunDto = createTestRunDtoForProject(testUrl);
+        final String testUrl = "https://services.interactive-instruments.de/cite-xs-46/simpledemo/cgi-bin/cities-postgresql/wfs?request=GetCapabilities&service=wfs";
+        TestRunDto testRunDto = createTestRunDtoForProject(testUrl);
 
-		final TestRun testRun = testDriverManager.createTestRun(testRunDto);
-		final TaskPoolRegistry<TestRunDto, TestRun> taskPoolRegistry = new TaskPoolRegistry<>(1, 1);
-		testRun.init();
-		taskPoolRegistry.submitTask(testRun);
-		final TestRunDto runResult = taskPoolRegistry.getTaskById(testRunDto.getId()).waitForResult();
+        final TestRun testRun = testDriverManager.createTestRun(testRunDto);
+        final TaskPoolRegistry<TestRunDto, TestRun> taskPoolRegistry = new TaskPoolRegistry<>(1, 1);
+        testRun.init();
+        taskPoolRegistry.submitTask(testRun);
+        final TestRunDto runResult = taskPoolRegistry.getTaskById(testRunDto.getId()).waitForResult();
 
-		assertNotNull(runResult);
-		assertNotNull(runResult.getTestTaskResults());
-		assertFalse(runResult.getTestTaskResults().isEmpty());
-	}
+        assertNotNull(runResult);
+        assertNotNull(runResult.getTestTaskResults());
+        assertFalse(runResult.getTestTaskResults().isEmpty());
+    }
 
-	@Test
-	public void T4_runTestInvalidUrl() throws Exception, ComponentNotLoadedException {
-		final String testUrl = "http://example.com";
-		TestRunDto testRunDto = createTestRunDtoForProject(testUrl);
+    @Test
+    public void T4_runTestInvalidUrl() throws Exception, ComponentNotLoadedException {
+        final String testUrl = "http://example.com";
+        TestRunDto testRunDto = createTestRunDtoForProject(testUrl);
 
-		final TestRun testRun = testDriverManager.createTestRun(testRunDto);
-		final TaskPoolRegistry<TestRunDto, TestRun> taskPoolRegistry = new TaskPoolRegistry<>(1, 1);
-		testRun.init();
-		taskPoolRegistry.submitTask(testRun);
+        final TestRun testRun = testDriverManager.createTestRun(testRunDto);
+        final TaskPoolRegistry<TestRunDto, TestRun> taskPoolRegistry = new TaskPoolRegistry<>(1, 1);
+        testRun.init();
+        taskPoolRegistry.submitTask(testRun);
 
-		final TestRunDto runResult = taskPoolRegistry.getTaskById(testRunDto.getId()).waitForResult();
-		assertNotNull(runResult);
-		final TestTaskResultDto result = runResult.getTestTasks().get(0).getTestTaskResult();
-		assertEquals(INTERNAL_ERROR, result.getResultStatus());
-		assertFalse(SUtils.isNullOrEmpty(result.getErrorMessage()));
-		assertTrue(result.getErrorMessage().contains("OGC TEAM Engine returned HTTP status code"));
-		// Todo not working with inmemory resultcollector
-		// assertEquals(2, result.getAttachments().size());
-		assertTrue(result.getTestModuleResults() == null || result.getTestModuleResults().isEmpty());
-	}
+        final TestRunDto runResult = taskPoolRegistry.getTaskById(testRunDto.getId()).waitForResult();
+        assertNotNull(runResult);
+        final TestTaskResultDto result = runResult.getTestTasks().get(0).getTestTaskResult();
+        assertEquals(INTERNAL_ERROR, result.getResultStatus());
+        assertFalse(SUtils.isNullOrEmpty(result.getErrorMessage()));
+        assertTrue(result.getErrorMessage().contains("OGC TEAM Engine returned HTTP status code"));
+        // Todo not working with inmemory resultcollector
+        // assertEquals(2, result.getAttachments().size());
+        assertTrue(result.getTestModuleResults() == null || result.getTestModuleResults().isEmpty());
+    }
 
-	// @Test(timeout = 90)
-	@Test
-	public void T5_timeoutTest() throws Exception, ComponentNotLoadedException {
+    // @Test(timeout = 90)
+    @Test
+    public void T5_timeoutTest() throws Exception, ComponentNotLoadedException {
 
-		final String testUrl = "https://services.interactive-instruments.de/cite-xs-46/simpledemo/cgi-bin/cities-postgresql/wfs?request=GetCapabilities&service=wfs";
-		final TestRunDto testRunDto = createTestRunDtoForProject(testUrl);
+        final String testUrl = "https://services.interactive-instruments.de/cite-xs-46/simpledemo/cgi-bin/cities-postgresql/wfs?request=GetCapabilities&service=wfs";
+        final TestRunDto testRunDto = createTestRunDtoForProject(testUrl);
 
-		final String timeout = "10";
+        final String timeout = "10";
 
-		testDriverManager.release();
-		testDriverManager.getConfigurationProperties().setProperty(TE_TIMEOUT_SEC, timeout);
-		assertEquals(timeout, testDriverManager.getConfigurationProperties().getProperty(TE_TIMEOUT_SEC));
-		testDriverManager.init();
-		testDriverManager.load(EidFactory.getDefault().createAndPreserveStr(TE_TEST_DRIVER_EID));
+        testDriverManager.release();
+        testDriverManager.getConfigurationProperties().setProperty(TE_TIMEOUT_SEC, timeout);
+        assertEquals(timeout, testDriverManager.getConfigurationProperties().getProperty(TE_TIMEOUT_SEC));
+        testDriverManager.init();
+        testDriverManager.load(EidFactory.getDefault().createAndPreserveStr(TE_TEST_DRIVER_EID));
 
-		final TestRun testRun = testDriverManager.createTestRun(testRunDto);
-		final TaskPoolRegistry<TestRunDto, TestRun> taskPoolRegistry = new TaskPoolRegistry<>(1, 1);
-		testRun.init();
-		taskPoolRegistry.submitTask(testRun);
+        final TestRun testRun = testDriverManager.createTestRun(testRunDto);
+        final TaskPoolRegistry<TestRunDto, TestRun> taskPoolRegistry = new TaskPoolRegistry<>(1, 1);
+        testRun.init();
+        taskPoolRegistry.submitTask(testRun);
 
-		final TestRunDto runResult = taskPoolRegistry.getTaskById(testRunDto.getId()).waitForResult();
-		assertNotNull(runResult);
-		final TestTaskResultDto result = runResult.getTestTasks().get(0).getTestTaskResult();
-		assertEquals(INTERNAL_ERROR, result.getResultStatus());
-		assertFalse(SUtils.isNullOrEmpty(result.getErrorMessage()));
-		assertTrue(
-				result.getErrorMessage().contains("OGC TEAM Engine is taking too long to respond. Timeout after " + timeout));
-		assertEquals(1, result.getAttachments().size());
-		assertTrue(result.getTestModuleResults() == null || result.getTestModuleResults().isEmpty());
-	}
+        final TestRunDto runResult = taskPoolRegistry.getTaskById(testRunDto.getId()).waitForResult();
+        assertNotNull(runResult);
+        final TestTaskResultDto result = runResult.getTestTasks().get(0).getTestTaskResult();
+        assertEquals(INTERNAL_ERROR, result.getResultStatus());
+        assertFalse(SUtils.isNullOrEmpty(result.getErrorMessage()));
+        assertTrue(
+                result.getErrorMessage().contains("OGC TEAM Engine is taking too long to respond. Timeout after " + timeout));
+        assertEquals(1, result.getAttachments().size());
+        assertTrue(result.getTestModuleResults() == null || result.getTestModuleResults().isEmpty());
+    }
 
 }

--- a/src/test/java/de/interactive_instruments/etf/testdriver/te/TeTestRunTaskFactoryTest.java
+++ b/src/test/java/de/interactive_instruments/etf/testdriver/te/TeTestRunTaskFactoryTest.java
@@ -78,7 +78,7 @@ public class TeTestRunTaskFactoryTest {
     private static TestDriverManager testDriverManager = null;
     private static DataStorage DATA_STORAGE = DataStorageTestUtils.inMemoryStorage();
 
-    private final static String VERSION = "1.26";
+    private final static String VERSION = "1.32";
     private final static String LABEL = "WFS 2.0 (OGC 09-025r2/ISO 19142) Conformance Test Suite";
     private final static EID wfs20EtsId = EidFactory.getDefault().createUUID(
             "http://cite.opengeospatial.org/teamengine/rest/suites/wfs20/");


### PR DESCRIPTION
Changes the ID generation algorithm for test suites imported from the Team Engine to be independent of the TE's deployment URL.

With an ID that depends on where the Team Engine is deployed, dependencies to imported test suites will be broken if a different deployment than `http://cite.opengeospatial.org/teamengine/` is used.

https://github.com/wetransform/service-publisher/pull/150
ING-426